### PR TITLE
V4: docker task overhaul

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 env:
   DOCKER_BUILDKIT: true

--- a/.kano/tasks/format
+++ b/.kano/tasks/format
@@ -13,7 +13,7 @@ format() {
 
 _format_shell() {
   _info "Formatting shell files"
-  shfmt -p -w -bn -ci -sr -i 2 .kano sources tests
+  shfmt -p -w -bn -ci -sr -i 2 .kano sources tests templates
 }
 
 _format_markdown_and_yaml() {

--- a/.kano/tasks/format
+++ b/.kano/tasks/format
@@ -13,7 +13,7 @@ format() {
 
 _format_shell() {
   _info "Formatting shell files"
-  shfmt -p -w -bn -ci -sr -kp -i 2 .kano sources tests
+  shfmt -p -w -bn -ci -sr -i 2 .kano sources tests
 }
 
 _format_markdown_and_yaml() {

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,4 @@
+default: true
+MD013:
+  line_length: 96
+  code_blocks: false

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,4 +1,0 @@
-{
-  "default": true,
-  "MD013": { "line_length": 96, "code_blocks": false }
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "printWidth": 96,
-  "proseWrap": "always",
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "none"
-}

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,2 @@
+printWidth: 96
+proseWrap: always

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -2,27 +2,60 @@
 
 > Read in [English](/docs/README.md)
 
-ILC d'automatisation de flux de travaux d'ingénierie logicielle
+ILC d'automatisation de processus d'ingénierie logicielle
 
 ## À propos
 
 > `κάνω` (phonétique : `káno`) signifie "faire" en grec
 
-Les processus d'ingénierie logicielle sont tous composés d'actions de base que les ingénieurs
-effectuent plusieurs fois par jour, tels qu'exécuter des tests automatisés, formatter le code,
-etc. L'implémentation de ces actions varie en fonction du langage de programmation, des outils
-utilisés par l'équipe et autres contraintes connexes. La plupart du temps, ces actions sont
-gérées par des scripts d'une ligne dans la configuration du gestionnaire de paquet du langage
-utilisé. Quand les choses deviennent plus complexes, ces scripts d'une ligne évoluent vite en
-longs scripts intestables avec des structures de répertoire variables et peu (ou pas) de
-documentation. Cela augmente aussi bien les coûts de maintenance que les coûts en charge
-cognitive lors de changement de contexte entre projets et d'intégration de nouveaux
-contributeurs
+Les processus d'ingénierie logicielle sont composés de plusieurs types d'activités. Certaines de
+ces activités (telles que la conception, la programmation, la documentation, etc.) sont
+créatives et apportent une valeur directe au projet. D'autres (comme la compilation, l'exécution
+de tests, la mise en forme de code, etc.), bien qu'elles soient aussi essentiels, n'en apportent
+pas. Une équipe d'ingénierie efficace devrait s'efforcer d'automatiser autant que possible ce
+genre d'activité sans valeur ajoutée
 
-Ceci est un des problèmes que `kano` résout. Il structure le processus de développement en
-_tâches_ qui peuvent être exécutées de la même manière à travers tous les projets, peu importe
-leur implémentation. Cela donne une interface commune avec laquelle travailler à travers tous
-les projets sans se mettre dans vos pattes
+`kano` est un outil qui aide justement à faire cela
+
+### Tâches (scripts conventionnés)
+
+Les activités sans valeur ajoutée peuvent souvent être complètement ou partiellement
+automatisées avec des scripts. L'implémentation de ces scripts dépend du langage de
+programmation, des outils et des processus utilisés par l'équipe. Pour les projets simples, des
+scripts d'une ligne intégrés dans la configuration du gestionnaire de paquets du langage peuvent
+souvent suffire. Mais à mesure que les projets évoluent, ces lignes ont tendance à devenir des
+fichiers de script entiers orchestrant plusieurs outils et utilitaires
+
+Les fichiers de script sont extrêmement utiles, mais ont la mauvaise habitude de devenir
+illisibles et difficiles à maintenir. D'un projet à l'autre, ils varient souvent en structure,
+format et qualité de documentation (s'il y'en a). Pire encore, certains peuvent se retrouver à être
+copiés-collés entre plusieurs projets, multipliant ainsi les efforts futurs nécessaires pour les
+modifier. Tous ces petits inconvénients s'additionnent et peuvent induire des coûts indésirables
+de charge cognitive, de maintenance et d'intégration qui peuvent en partie annuler les gains en
+efficacité que ces scripts auraient initialement pu faire gagner à l'équipe
+
+Ce sont là quelques-uns des problèmes que `kano` vise à résoudre. Il propose une convention pour
+organiser, formater, documenter et exécuter des scripts à travers les projets. Il structure les
+scripts d'un projet en _tâches_ (scripts conventionnés) et fournit une interface de ligne de
+commande simple pour les exécuter sans se mettre au travers du chemin. Il gère également
+plusieurs niveaux de tâches pour permettre à une équipe de partager et de réutiliser facilement
+un groupe de tâches ou à un ingénieur de personnaliser son flux de travail personnel
+
+### Environnement de développement partagé avec Docker (facultatif)
+
+Les tâches sont une partie importante de l'automatisation du travail sans valeur ajoutée, mais
+pas le tableau complet. Comme les tâches sont exécutées dans un environnement (architecture CPU,
+système d'exploitation, etc.), différents environnements peuvent produire des résultats
+différents. Cet indéterminisme peut également annuler une partie des gains en efficacité que ces
+tâches auraient initialement pu faire gagner à l'équipe
+
+Pour que les tâches produisent des résultats déterministes, elles doivent être exécutées dans un
+environnement déterministe. Cet environnement doit être partagé par tous les acteurs, y compris
+les automates d'intégration continue (IC) et de déploiement continue (DC). La meilleure façon
+d'y parvenir est d'utiliser [Docker](https://www.docker.com). `kano` a une tâche intégrée qui
+simplifie le développement et l'exécution de tâches à l'intérieur d'un conteneur Docker. Il
+accélère considérablement les processus IC/DC, le déboguage de problèmes d'environnement et à
+l'intégration de nouveaux contributeurs
 
 ## Licence
 
@@ -72,7 +105,7 @@ Une image Docker de dévelopment est utilisée afin d'encapsuler les dépendance
 que son environnement d'exécution. Pour bâtir l'image :
 
 ```shell
-kano docker build
+kano docker image build
 ```
 
 > Voir le [guide d'utilisation Docker](/docs/fr/tasks/docker.md) pour plus d'informations
@@ -168,4 +201,4 @@ Pour publier une version du projet sur GitHub et mettre à jour l'index de paque
 kano release VERSION GIT_NAME GIT_EMAIL GITHUB_ACCESS_TOKEN
 ```
 
-> `VERSION` devrait être en format sémantique standard ou un nom de beta
+> `VERSION` devrait être en format sémantique standard ou un nom de beta (`beta-*`)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -28,17 +28,17 @@ fichiers de script entiers orchestrant plusieurs outils et utilitaires
 
 Les fichiers de script sont extrêmement utiles, mais ont la mauvaise habitude de devenir
 illisibles et difficiles à maintenir. D'un projet à l'autre, ils varient souvent en structure,
-format et qualité de documentation (s'il y'en a). Pire encore, certains peuvent se retrouver à être
-copiés-collés entre plusieurs projets, multipliant ainsi les efforts futurs nécessaires pour les
-modifier. Tous ces petits inconvénients s'additionnent et peuvent induire des coûts indésirables
-de charge cognitive, de maintenance et d'intégration qui peuvent en partie annuler les gains en
-efficacité que ces scripts auraient initialement pu faire gagner à l'équipe
+format et qualité de documentation (s'il y'en a). Pire encore, certains peuvent se retrouver à
+être copiés-collés entre plusieurs projets, multipliant ainsi les efforts futurs nécessaires
+pour les modifier. Tous ces petits inconvénients s'additionnent et peuvent induire des coûts
+indésirables de charge cognitive, de maintenance et d'intégration qui peuvent en partie annuler
+les gains en efficacité que ces scripts auraient initialement pu faire gagner à l'équipe
 
 Ce sont là quelques-uns des problèmes que `kano` vise à résoudre. Il propose une convention pour
 organiser, formater, documenter et exécuter des scripts à travers les projets. Il structure les
 scripts d'un projet en _tâches_ (scripts conventionnés) et fournit une interface de ligne de
 commande simple pour les exécuter sans se mettre au travers du chemin. Il gère également
-plusieurs niveaux de tâches pour permettre à une équipe de partager et de réutiliser facilement
+plusieurs portées de tâches pour permettre à une équipe de partager et de réutiliser facilement
 un groupe de tâches ou à un ingénieur de personnaliser son flux de travail personnel
 
 ### Environnement de développement partagé avec Docker (facultatif)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -115,6 +115,9 @@ pendant les tests. Pour voir le rapport de couverture après une exécution des 
 kano coverage
 ```
 
+> NOTE: Les _strings_ multilignes pourraient s'afficher comme non-couvertes à cause de cette
+> [_issue_](https://github.com/SimonKagstrom/kcov/issues/145)
+
 ### Dev
 
 Pour changer la version de `kano` utilisée à celle en développement :

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,18 +8,48 @@ Software engineering workflow automation CLI
 
 > `κάνω` (phonetic: `káno`) is greek for "do" or "make"
 
-Software engineering workflows are all composed of basic actions that engineers make multiple
-times per day, such as running tests, formatting code, etc. The implementation of these actions
-will vary depending on the language, the tools the team uses and other such concerns. Most of
-the time, this is handled through one-liner scripts in the language's package manager
-configuration. When things get more complex, these one-liners rapidly evolve into big untestable
-scripts with varying folder structures and poor documentation. It drives up the maintenance
-costs as well as the cognitive costs of switching between projects and onboarding new
-contributors
+Software engineering workflows are composed of multiple types of activities. Some of these
+activities (such as designing, coding, documenting, etc.) are creative and contribute direct
+value to the project. Others (such as building, running tests, formatting code, etc.), while
+still essential, do not. An efficient engineering team should strive to automate as much of this
+non-value-added work as possible
 
-This is one of the problems `kano` solves. It structures the development workflow in _tasks_
-that can be run the same way across projects, regardless of their actual implementations. It
-provides a common interface to work with across all projects without getting in the way
+`kano` is a tool that helps to do just that
+
+### Tasks (conventionalized scripts)
+
+Non-value-added activities can often be completely or partially automated with scripts. The
+implementation of these scripts depends on the programming language, the tools and the processes
+the team uses. For simple projects, inlined scripts in the language's package manager
+configuration is often enough. But as projects evolve, one-liners have a tendency to become
+stand-alone script files orchestrating multiple tools and utilities
+
+Script files are extremely useful, but have the bad habit of becoming unreadable and hard to
+maintain. From one project to the other, they will often differ in organization, format and
+quality of documentation (if any). Worse, some might even be copy-pasted between projects,
+multiplying the future efforts needed to modify them. All these little inconveniences add up and
+can induce undesired cognitive load, maintenance and onboarding costs that can partly negate the
+efficiency these script files might initially have gained the team
+
+These are some of the problems `kano` aims to solve. It proposes a convention to organize,
+format, document and run scripts across projects. It structures a project's scripts into _tasks_
+(conventionalized scripts) and provides a simple command-line interface to execute them without
+getting in the way. It also handles multiple _scopes_ of tasks to allow a team to easily share
+and reuse a group of tasks or an engineer to customize his personal workflow
+
+### Shared development environment with Docker (optional)
+
+_Tasks_ are an important part of automating non-value-added work, but not the complete picture.
+As tasks are executed in an _environment_ (CPU architecture, operating system, etc.), different
+environments may produce different outcomes. This indeterminism may also negate some of the
+efficiency that tasks initially have gained the team
+
+For tasks to have deterministic outcomes, they must be executed in a deterministic environment.
+This environment must be shared by all actors, including continuous integration (_CI_) and
+continuous deployment (_CD_) bots. The best way to achieve this is using
+[Docker](https://www.docker.com). `kano` has a builtin task that simplifies developing and
+running tasks inside a Docker container. It greatly accelerates CI/CD workflows, debugging
+environment-related problems and onboarding new contributors
 
 ## License
 
@@ -69,7 +99,7 @@ A development docker image is used to encapsulate project dependencies and runti
 To build the image:
 
 ```shell
-kano docker build
+kano docker image build
 ```
 
 > See the [Docker user guide](/docs/en/tasks/docker.md) for more information
@@ -112,7 +142,7 @@ view the coverage report after a test run:
 kano coverage
 ```
 
-> NOTE: Multiline strings may report as uncovered due this
+> NOTE: Multiline strings may report as non-covered due this
 > [issue](https://github.com/SimonKagstrom/kcov/issues/145)
 
 ### Dev
@@ -165,4 +195,4 @@ To release a version of the project on GitHub and update logisparte's package in
 kano release VERSION GIT_NAME GIT_EMAIL GITHUB_ACCESS_TOKEN
 ```
 
-> `VERSION` should be in standard semantic versioning format or a beta name
+> `VERSION` should be in standard semantic versioning format or a beta name (`beta-*`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,9 @@ view the coverage report after a test run:
 kano coverage
 ```
 
+> NOTE: Multiline strings may report as uncovered due this
+> [issue](https://github.com/SimonKagstrom/kcov/issues/145)
+
 ### Dev
 
 To change the version of `kano` to the one under development:

--- a/docs/en/tasks/docker.md
+++ b/docs/en/tasks/docker.md
@@ -217,6 +217,20 @@ kano docker stop [OPTIONS]
 
 > Usual `docker container stop` options and flags may also be provided
 
+#### container kill
+
+To kill and discard the running container:
+
+```shell
+kano docker container kill [OPTIONS]
+
+# or
+
+kano docker kill [OPTIONS]
+```
+
+> Usual `docker container kill` options and flags may also be provided
+
 ### Shortcuts
 
 `kano docker` provides additional subcommands, that do not have native `docker` counterparts,
@@ -268,7 +282,7 @@ To remove all traces of kano development image and container for the current pro
 kano docker clean
 ```
 
-- If the development container is running, it will stop and discard it
+- If the development container is running, it will kill and discard it
 - If the development container exists but is not running, it will discard it
 - If the development image exists, it will delete it
 

--- a/docs/en/tasks/docker.md
+++ b/docs/en/tasks/docker.md
@@ -8,104 +8,473 @@ Use the `docker` task to work in an isolated development docker container
 
 > This task requires [Docker](https://github.com/docker)
 
+## Summary
+
+- `kano docker` subcommands relay options and flags to their native `docker` CLI counterpart, if
+  they have one
+- The project must contain a `Dockerfile` from which the developement image will be built
+- The image must contain all of the project's dependencies
+- The container will be created from the image
+- By default, the container will mount the project directory
+- The container can also mount various host directories, files and environment variables,
+  customizable by the user, optionally through higher `kano` scopes
+- To use kano inside the container, `kano` must be installed in it too (until the self-mount
+  feature is implemented)
+
+| Variable                | Description                 | Default                         |
+| :---------------------- | :-------------------------- | :------------------------------ |
+| `KANO_DOCKER_FILE`      | Dockerfile path             | `.kano/Dockerfile`              |
+| `KANO_DOCKER_REGISTRY`  | Docker registry URL, if any |                                 |
+| `KANO_DOCKER_IMAGE`     | Development image name      | `${PROJECT_NAME}-dev`           |
+| `KANO_DOCKER_CONTAINER` | Development container name  | `${PROJECT_NAME}-dev-container` |
+| `KANO_DOCKER_TAG`       | Image tag to work with      | `latest`                        |
+
+> The variable `KANO_DOCKER` will be set to `true` inside the container
+
 ## Usage
 
-If a `Dockerfile` is present in the local `.kano` directory, it will be used to create the
-project's development environment image. This image will be used to create the development
-container and should contain all of the project's system dependencies
+By default, if a `Dockerfile` is present in the local `.kano` directory, it will be used to
+create the project's development environment image. This image will then be used to create the
+development container
 
-### Build
+> The `Dockerfile` location can be customized using the `KANO_DOCKER_FILE` environment variable
+
+### Image
+
+The development image should contain all of the project's system dependencies. Ideally, a new
+contributor should only be required to have `git`, `docker` and `kano` installed on the host
+machine. Everything else should be installed inside the image, including `kano` (until the
+self-mount feature is implemented)
+
+#### image build
 
 To build the project's development image:
 
 ```shell
-kano docker build
+kano docker image build [OPTIONS]
+
+# or
+
+kano docker build [OPTIONS]
 ```
 
-> Usual `docker build` options and flags may be provided
+> Usual `docker image build` options and flags may be provided
 
-This image will be named `${PROJECT_NAME}-dev`
+By default, this image will be named `${PROJECT_NAME}-dev`. Its name can be customized by
+setting the `KANO_DOCKER_IMAGE` environment variable (preferably in the project's
+`.kano/environment` file)
 
-> The image name can be customized through the `KANO_DEVELOPMENT_IMAGE` environment variable in
-> the project's `.kano/environment` file
+The built image's default tag is `latest`. Alternatively, the `KANO_DOCKER_TAG` can be set to
+work on an already versioned image. In this case, the development image will fail to build and,
+if not locally available, should be pulled instead. The resulting local
+`$KANO_DOCKER_IMAGE:$KANO_DOCKER_TAG` will be referred to the _working image_ in the following
+sections
 
-### Delete
+#### image rm
 
-To delete the project's development image:
+To delete the working image:
 
 ```shell
-kano docker delete
+kano docker image rm [OPTIONS]
+
+# or
+
+kano docker rmi [OPTIONS]
 ```
 
-### Run
+> Usual `docker image rm` options and flags may be provided
 
-To run a command in an ephemeral development container:
+#### image tag
+
+To tag the working image:
 
 ```shell
-kano docker run [OPTIONS] COMMAND
+kano docker image tag TAG_NAME
+
+# or
+
+kano docker tag TAG_NAME
 ```
 
-> Usual `docker run` options and flags may be provided
+#### image pull
 
-By default, this container will:
+To pull the working image from the registry:
 
-- Have an auto-generated name
+```shell
+kano docker image pull [OPTIONS] [TAG_NAME]
+
+# or
+
+kano docker pull [OPTIONS] [TAG_NAME]
+```
+
+> Only available if the `KANO_DOCKER_REGISTRY` environment variable is set and the user has
+> logged in using `docker login`. Usual `docker image pull` options and flags may also be
+> provided
+
+#### image push
+
+To push the working image to the registry:
+
+```shell
+kano docker image pull [OPTIONS] [TAG_NAME]
+
+# or
+
+kano docker pull [OPTIONS] [TAG_NAME]
+```
+
+> Only available if the `KANO_DOCKER_REGISTRY` environment variable is set and the user has
+> logged in using `docker login`. Usual `docker image push` options and flags may also be
+> provided
+
+### Container
+
+The development container is created from the working image and is ephemeral. It is designed to
+be reusable, but discarded when stopped. The container may be customized by mounting various
+host directories, files and environment variables. It can be interacted with simply from the
+command line, or by attaching an editor/IDE to it for increased productivity
+
+#### container create
+
+To create a container from the working image:
+
+```shell
+kano docker container create [OPTIONS]
+
+# or
+
+kano docker create [OPTIONS]
+```
+
+> Usual `docker container create` options and flags may also be provided
+
+By default, this container will be named `${PROJECT_NAME}-dev-container`. Its name can be
+customized by setting the `KANO_DOCKER_CONTAINER` environment variable (preferably in the
+project's `.kano/environment` file). This container will also:
+
+- Be ephemeral
 - Be non-interactive
-- Be non-persistent
 - Not create log files
-- Have the project directory mounted as a volume
-- Have the project directory set as the working directory
+- Mount the project directory as a volume
+- Set the project directory as its working directory
+- Have a password-less sudo user with the same name and home directory as the host user
+- Set the environment variable `KANO_DOCKER` to `true`
 
-### Start
+#### container rm
 
-To start a development container in the background in order to attach to it later:
+To discard the created but unstarted container:
 
 ```shell
+kano docker container rm [OPTIONS]
+
+# or
+
+kano docker rm [OPTIONS]
+```
+
+> Usual `docker container rm` options and flags may also be provided
+
+#### container start
+
+To start the created container:
+
+```shell
+kano docker container start [OPTIONS]
+
+# or
+
 kano docker start [OPTIONS]
 ```
 
-> Usual `docker run` options and flags may be provided
+> Usual `docker container start` options and flags may also be provided
 
-By default, this container will:
+#### container exec
 
-- Be named `${PROJECT_NAME}-dev-container`
-- Be interactive
-- Be non-persistent
-- Not create log files
-- Have the project directory mounted as a volume
-- Have the project directory set as the working directory
-
-> The container name can be customized through the `KANO_DEVELOPMENT_CONTAINER` environment
-> variable in the project's `.kano/environment` file
-
-### Stop
-
-To stop the running development container:
+To exec a command inside the running container:
 
 ```shell
-kano docker stop
+kano docker container exec [OPTIONS] COMMAND
+
+# or
+
+kano docker exec [OPTIONS] COMMAND
 ```
 
-### Attach
+> Usual `docker container exec` options and flags may also be provided
 
-To attach to the running development container:
+#### container stop
+
+To stop and discard the running container:
 
 ```shell
-kano docker attach
+kano docker container stop [OPTIONS]
+
+# or
+
+kano docker stop [OPTIONS]
 ```
 
-> Usual `docker attach` options and flags may be provided
+> Usual `docker container stop` options and flags may also be provided
 
-When attached, to exit the container:
+### Shortcuts
+
+`kano docker` provides additional subcommands, that do not have native `docker` counterparts,
+that help increase productivity
+
+#### boot
+
+To ensure there's a running development container:
 
 ```shell
-exit
+kano docker boot
 ```
 
-### Enter
+- If the development image does not exist, it will try to build it
+- If the development container does not exist, it will create it
+- If the development container is not running, it will start it
 
-To [start](###start) and [attach](###attach) at once:
+#### execute
+
+To run a command in a development container:
 
 ```shell
-kano docker enter
+kano docker execute [OPTIONS] COMMAND
 ```
+
+- It will `kano docker boot`
+- It will `kano docker container exec` the command in the running container
+
+> `docker container exec` options and flags may also be provided
+
+#### shell
+
+To open an interactive login shell in a development container:
+
+```shell
+kano docker shell
+```
+
+- It will `kano docker execute` the same shell than the host's user `$SHELL`, or `/bin/sh` if
+  not defined
+
+> Tip: to close the shell and return the host, just use the `exit` command
+
+#### clean
+
+To remove all traces of kano development image and container for the current project:
+
+```shell
+kano docker clean
+```
+
+- If the development container is running, it will stop and discard it
+- If the development container exists but is not running, it will discard it
+- If the development image exists, it will delete it
+
+## Examples
+
+### Workflows
+
+Building the image, creating the container, starting it and attaching
+[Visual Studio Code](https://code.visualstudio.com) to it using the
+[Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers):
+
+```shell
+kano docker boot
+# Open the command palette in vscode
+# Select "Remote - Containers: Attach to Running Container..."
+# Select the project's development container
+```
+
+Opening a shell in the same container:
+
+```shell
+kano docker shell
+```
+
+Opening another shell in the same container:
+
+```shell
+# In a different terminal
+kano docker shell
+```
+
+Running a command inside the container:
+
+```shell
+kano docker execute some_command
+```
+
+Stopping the container, discarding it and cleaning everything up:
+
+```shell
+kano docker clean
+```
+
+#### Visual Studio Code configuration
+
+By default, VS Code tries to install its remote extension server in the container as `root`. If
+the development image default user is not `root` (good practice), this operation will fail. To
+correct this behavior, a configuration file setting the correct user for the container must
+created. This file must only be created once per project, unless the container name changes.
+[This kano task](/templates/vscode/tasks/configure_vscode) may be used to generate it
+automatically
+
+### Customizing the developement container
+
+The development container can be customized using volumes, environment variables and more. The
+most common use case would be to replicate one's personal development configurations inside the
+container for increased productivity when working in it. The following sections will focus on
+demonstrating this particular use case
+
+#### Configuring customizations
+
+The simplest way to configure the container is to create it using standard docker options and
+flags. For example, to mount one's personal shell profile and git configuration, simply create
+the container with the appropriate option:
+
+```shell
+kano docker container create \
+  --volume $HOME/.profile:$HOME/.profile \
+  --volume $HOME/.gitconfig:$HOME/.gitconfig \
+  --volume $HOME/.gitignore_global:$HOME/.gitignore_global
+```
+
+While useful, having to manually type all desired options everytime a container is created may
+prove tedious, most [shortcuts](#shortcuts) will also not pick them up. The best way to
+customize containers is to use a proxying kano user task, also named `docker`. This task should
+have the following form:
+
+```shell
+#!/bin/sh
+
+docker_help() {
+  echo "Proxies the builtin docker task with my personal configurations"
+}
+
+docker() {
+  # shellcheck disable=SC2046
+  kano --next docker $(_insert_my_personal_docker_options "$@" | xargs)
+}
+
+_insert_my_personal_docker_options() {
+  if [ "$1" = "container" ]; then
+    echo "$1" && shift
+  fi
+
+  if [ "$1" = "create" ]; then
+    echo "$1" && shift
+    _echo_my_container_create_options
+  fi
+
+  echo "$@"
+}
+
+_echo_my_container_create_options() {
+  echo "--volume $HOME/.profile:$HOME/.profile"
+  echo "--volume $HOME/.gitconfig:$HOME/.gitconfig"
+  echo "--volume $HOME/.gitignore_global:$HOME/.gitignore_global"
+}
+```
+
+> The proxy is made possible by the override `--next` flag. More information on override flags
+> can be found [here](/docs/en/usage.md##scopes)
+
+With such a proxying user task, all bare `kano docker container create` commands, including
+[shortcuts](#shortcuts), will now include one's shell profile and git configurations. The same
+principle could be applied with a proxying team task for team configurations, or directly in the
+project for project-specific configurations, such as network names or exposed ports
+
+#### Example customizations
+
+There are many customizations one could possibly seek to configure. The followings are some
+examples of options and flags that could be used in each case
+
+##### TERM
+
+To have consistent terminal colors with the host OS:
+
+```shell
+--env TERM="$TERM"
+```
+
+##### bash
+
+To mount one's `bash` configuration:
+
+```shell
+--volume "$HOME/.bashrc:$HOME/.bashrc"
+```
+
+> `bash` must also be installed in the development image
+
+##### zsh
+
+To mount one's `zsh` configuration:
+
+```shell
+--volume "$HOME/.zshenv:$HOME/.zshenv"
+--volume "$HOME/.zshrc:$HOME/.zshrc"
+```
+
+> `zsh` must also be installed in the development image
+
+##### git
+
+To mount one's `git` configuration:
+
+```shell
+--volume "$HOME/.gitconfig:$HOME/.gitconfig"
+--volume "$HOME/.gitignore_global:$HOME/.gitignore_global"
+```
+
+> `git` must also be installed in the development image
+
+##### vim
+
+To mount one's vim configuration:
+
+```shell
+--volume "$HOME/.vim:$HOME/.vim"
+--volume "$HOME/.vimrc:$HOME/.vimrc"
+--env EDITOR="/usr/bin/vim"
+```
+
+> `vim` must also be installed in the development image
+
+##### ssh
+
+To mount one's `ssh` configuration:
+
+```shell
+--volume "$HOME/.ssh:$HOME/.ssh"
+--volume "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
+--env SSH_AUTH_SOCK="$SSH_AUTH_SOCK"
+```
+
+This will forward the host's ssh agent in the docker container
+
+> `ssh-client` must also be installed in the development image
+
+###### ssh and macOS
+
+If macOS Keychain is used to manage ssh passphrases, mounting the host's `ssh` configuration
+will not work directly since Keychain will not be available in the container. To work around
+this situation, the following configuration can be added to `$HOME/.ssh/config` to prompt for
+passphrases once per session if Keychain is not found:
+
+```text
+IgnoreUnknown UseKeychain
+UseKeychain yes
+AddKeysToAgent yes
+```
+
+##### gpg
+
+Although it's possible to have `gnupg2` installed in the container and the host's configuration
+mounted, no way has been found yet to properly share GPG keys with the container that works with
+both MacOS and Linux hosts because mounting the GPG socket
+[will likely never be supported by Docker for Mac](https://github.com/docker/for-mac/issues/483).
+A workaround with minimal impact on productivity is to simply use GPG outside the container for
+actions that require one's GPG keys, such as signing a git commit or tag

--- a/docs/en/tasks/dockered.md
+++ b/docs/en/tasks/dockered.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Use the `dockered` task to execute a task inside an ephemeral development container
+Use the `dockered` task to execute a task inside a development container
 
 ## Usage
 
@@ -14,12 +14,13 @@ To execute a task inside a development container :
 kano dockered TASK
 ```
 
-> `kano` must also be installed in the development image
+> `kano` must also be installed in the development image (until the self-mount feature is
+> implemented)
 
 ### Note
 
 This task uses the [docker](/docs/en/tasks/docker.md) task and is equivalent to:
 
 ```shell
-kano docker run kano TASK
+kano docker execute kano TASK
 ```

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -23,7 +23,7 @@ kano TASK_NAME
 
 ### Define a task
 
-A task file is a sourceable shell file. It must have the following format:
+A task file is a shell script file. It must have the following format:
 
 ```shell
 #!/bin/sh
@@ -34,34 +34,37 @@ some_task_name() {
 
 ```
 
-Its name must exactly match its function name (here `some_task_name`) and have no extension
+Its name must exactly match its main function name (here `some_task_name`) and have no extension
 
-> You can use `kano init task TASK_NAME` to quickly create an empty task template
+> `kano init task TASK_NAME` can used to quickly create an empty task template
 
 ## Scopes
 
-Kano looks up for tasks in up to 5 different scopes, each represented by a specific directory:
+`kano` looks up for tasks in up to 5 different scopes, each represented by a specific directory.
+From innermost to outermost, these scopes are:
 
-|  Scope  |           Directory            | Tasks availability |
-| :-----: | :----------------------------: | :----------------: |
-| Project |          `$PWD/.kano`          |  In project only   |
-|  User   |       `$HOME/.kano_user`       |  Always for user   |
-|  Team   | `$HOME/.kano_teams/$KANO_TEAM` | Always for user\*  |
-| System  |          `/etc/kano`           |       Always       |
-| Builtin |        Included in kano        |       Always       |
+| Scope   | Directory                      | Tasks availability    |
+| :------ | :----------------------------- | :-------------------- |
+| Project | `$PWD/.kano`                   | In project only       |
+| User    | `$HOME/.kano_user`             | Always for user       |
+| Team    | `$HOME/.kano_teams/$KANO_TEAM` | Always for user\*     |
+| System  | `/etc/kano`                    | Always, for all users |
+| Builtin | Included in `kano`             | Always, for all users |
 
 > \* When `$KANO_TEAM` is set
 
-When a task execution is requested, kano will look for its file first in project (if it exists),
-then in user (if it exists), then in team (if `$KANO_TEAM` is set to the team's name and it
-exists), then in system (if it exists) and finally in the builtin scope until found. If a task
-is defined in 2 scopes, the file in the first scope encountered will be used. To override this
-resolution, a flag may be provided
+When a task execution is requested, `kano` will look for its file starting in the innermost
+available scope, and up to the outermost scope until it finds it. If a task is defined in
+multiple scopes, the first found file will be used. To override this resolution, a flag may be
+provided
 
 To force a **user** resolution:
 
 ```shell
 kano -u some_task
+
+# or
+
 kano --user some_task
 ```
 
@@ -69,6 +72,9 @@ To force a **team** resolution:
 
 ```shell
 kano -t some_task
+
+# or
+
 kano --team some_task
 ```
 
@@ -78,6 +84,9 @@ To force a **system** resolution:
 
 ```shell
 kano -s some_task
+
+# or
+
 kano --system some_task
 ```
 
@@ -85,49 +94,47 @@ To force a **builtin** resolution:
 
 ```shell
 kano -b some_task
+
+# or
+
 kano --builtin some_task
 ```
 
-> Project tasks have priority by default
-
 There is also a special flag `-x` or `--next` that can be used inside a task to delegate to the
-next scope. This is useful when overriding a task in a higher scope to delegate execution. See
-the [docker guide](/docs/en/tasks/docker.md) for a concrete example
+next available scope. This is useful when overriding a task in an outer scope to delegate
+execution. See the
+[docker task documentation](/docs/en/tasks/docker.md#configuring-customizations) for a concrete
+example
 
 ## Environment
 
-An environment file is a simple shell file that exports variables that will be available in its
-related tasks. There may be one environment file for each scope. Each environment file must
-contain variables that are specific to their respective scopes, or that redefine higher scope
-variables (see below)
+An environment file is a simple shell script file that exports variables that will be available
+in its related tasks. There may be one environment file for each scope. Each environment file
+must contain variables that are specific to their respective scopes, or that redefine outer
+scope variables (see below)
 
-Whenever kano runs a task, it sources all `environment` files available, from the highest scope
-down to the task, if any exists
+Whenever `kano` runs a task, it first sources all `environment` files available in order, from
+the outermost scope down to the task's. This way, if the same variable exists in two scopes, the
+innermost value will be used
 
-|  Scope  |                    File                    | Available environments in tasks  |
-| :-----: | :----------------------------------------: | :------------------------------: |
-| Project |          `$PWD/.kano/environment`          | Project, user, team\* and system |
-|  User   |       `$HOME/.kano_user/environment`       |     User, team\* and system      |
-|  Team   |  `$HOME/.kano_user/$KANO_TEAM/environment` |        Team\* and system         |
-| System  |          `/etc/kano/environment`           |           System only            |
+| Scope   | File                                      | Available environments in tasks  |
+| :------ | :---------------------------------------- | :------------------------------- |
+| Project | `$PWD/.kano/environment`                  | Project, user, team\* and system |
+| User    | `$HOME/.kano_user/environment`            | User, team\* and system          |
+| Team    | `$HOME/.kano_user/$KANO_TEAM/environment` | Team\* and system                |
+| System  | `/etc/kano/environment`                   | System only                      |
 
 > \* When `$KANO_TEAM` is set
 
-For example, when a project task execution is requested, kano first sources the system
-environment file (if it exists), then sources the team environment file (if `$KANO_TEAM` is set
-to the team's name and it exists), then sources the user environment file (if it exists) and
-then the project environment file (if it exists). This way, if a variable is exported both in
-project and user environment files, the project file variable value will have precedence
-
 ## Builtin tasks
 
-Some tasks are included with kano. They are related to kano itself and its general usage.
+Some tasks are included with `kano`. They are related to `kano` itself and its general usage
 
 > Builtin tasks are documented [here](/docs/en/tasks)
 
 ## Helpers
 
-Kano includes a collection of POSIX-compatible functions that simplify writing tasks. To use
+`kano` includes a collection of POSIX-compatible functions that simplify writing tasks. To use
 them, task files must simply source their required helpers:
 
 ```shell
@@ -137,6 +144,7 @@ them, task files must simply source their required helpers:
 . "$KANO_HELPERS/report"
 . "$KANO_HELPERS/fail"
 # ...
+
 ```
 
 > Helpers are documented [here](/docs/en/helpers)

--- a/docs/fr/tasks/docker.md
+++ b/docs/fr/tasks/docker.md
@@ -8,104 +8,494 @@ Utiliser la tâche `docker` pour travailler dans un conteneur de développement 
 
 > Cette tâche requiert [Docker](https://github.com/docker)
 
+## Résumé
+
+- Les sous-commandes `kano docker` relaient leurs options à leur homologue native dans l'ILC
+  `docker`, si elles en ont une
+- Le projet doit contenir un `Dockerfile` à part duquel l'image de développement sera bâtie
+- L'image doit contenir toutes les dépendances du projet
+- Le conteneur de développement sera créé à partir de l'image
+- Par défaut, le conteneur montera le répertoire du projet
+- Le conteneur peut aussi monter plusieurs répertoires, fichiers et variables d'environnement de
+  l'hôte, personnalisables par l'utilisateur, optionnellement via une tâche kano de portée
+  externe au projet
+- Pour utiliser `kano` à l'intérieur du conteneur, il doit aussi y être installé (jusqu'à ce que
+  la fonctionnalité d'auto-montage soit implémentée)
+
+<!-- markdownlint-disable line-length -->
+
+| Variable                | Description                            | Valeur par défaut               |
+| :---------------------- | :------------------------------------- | :------------------------------ |
+| `KANO_DOCKER_FILE`      | Chemin vers le Dockerfile              | `.kano/Dockerfile`              |
+| `KANO_DOCKER_REGISTRY`  | URL du registre Docker, le cas échéant |                                 |
+| `KANO_DOCKER_IMAGE`     | Nom de l'image de développement        | `${PROJECT_NAME}-dev`           |
+| `KANO_DOCKER_CONTAINER` | Nom du conteneur de développement      | `${PROJECT_NAME}-dev-container` |
+| `KANO_DOCKER_TAG`       | Marqueur de l'image à utiliser         | `latest`                        |
+
+<!-- markdownlint-enable line-length -->
+
+> The variable `KANO_DOCKER` will be set to `true` inside the container
+
 ## Usage
 
-Si un `Dockerfile` est présent dans le répertoire `.kano` local, il sera utilisé pour créer
-l'image de l'environnement de développement du projet. Cette image sera utilisée pour créer le
-conteneur de développement et devrait contenir toutes les dépendances systèmes du projet
+Par défaut, si un `Dockerfile` est présent dans le répertoire `.kano` local, il sera utilisé
+pour créer l'image de l'environnement de développement du projet. Cette image sera utilisée pour
+créer le conteneur de développement
 
-### Build
+> Le chemin vers le `Dockerfile` peut être personnalisé via la variable d'environnement
+> `KANO_DOCKER_FILE`
+
+### Image
+
+L'image de développement devrait contenir toutes les dépendances **systèmes** du projet.
+Idéalement, un nouveau contributeur n'aurait qu'à avoir `git`, `docker` et `kano` d'installé sur
+sa machine hôte. Toutes les autres dépendances système devraient être installé dans l'image,
+incluant `kano` (jusqu'à ce que la fonctionnalité d'auto-montage soit implémentée)
+
+#### image build
 
 Pour bâtir l'image de développement du projet :
 
 ```shell
-kano docker build
+kano docker image build [OPTIONS]
+
+# ou
+
+kano docker build [OPTIONS]
 ```
 
-> Les options usuelles de `docker build` peuvent être utilisées
+> Les options usuelles de `docker image build` peuvent être utilisées
 
-L'image sera nommée `${PROJECT_NAME}-dev`
+Par défaut, cette image sera nommée `${PROJECT_NAME}-dev`. Son nom peut être personnalisé via la
+variable d'environnement `KANO_DOCKER_IMAGE` (préférablement dans le fichier `.kano/environment`
+du projet)
 
-> Le nom de l'image peut être personnalisé via la variable d'environnement
-> `KANO_DEVELOPMENT_IMAGE` dans le fichier `.kano/environment` du projet
+Le marqueur par défaut de l'image bâtie sera `latest`. Il est également possible de travailler
+sur une image versionnée en utilisant la variable d'environnement `KANO_DOCKER_TAG`. Dans ce
+cas, l'image de développement ne pourra être bâtie et devra soit déjà être présente localement
+ou téléchargée depuis un registre Docker. Cette image qualifiée
+`$KANO_DOCKER_IMAGE:$KANO_DOCKER_TAG` sera appelée _image de travail_ dans les sections
+suivantes
 
-### Delete
+#### image rm
 
-Pour effacer l'image de développement du projet :
+Pour effacer l'image de travail :
 
 ```shell
-kano docker delete
+kano docker image rm [OPTIONS]
+
+# ou
+
+kano docker rmi [OPTIONS]
 ```
 
-### Run
+> Les options usuelles de `docker image rm` peuvent être utilisées
 
-Pour exécuter une commande dans un conteneur de développement éphémère :
+#### image tag
+
+Pour marquer une image de travail :
 
 ```shell
-kano docker run [OPTIONS] COMMANDE
+kano docker image tag MARQUEUR
+
+# ou
+
+kano docker tag MARQUEUR
 ```
 
-> Les options usuelles de `docker run` peuvent être utilisées
+#### image pull
 
-Par défaut, ce conteneur:
-
-- Aura un nom auto-généré
-- Sera interactif
-- Sera non-persistent
-- Ne créera pas de fichiers de log
-- Aura le répertoire du projet embarqué comme volume
-- Aura le répertoire du projet configuré comme répertoire de travail
-
-### Start
-
-Pour démarrer un conteneneur de développement en arrière-plan afin de s'y attacher plus tard :
+Pour télécharger une image de travail depuis le registre :
 
 ```shell
+kano docker image pull [OPTIONS] [MARQUEUR]
+
+# ou
+
+kano docker pull [OPTIONS] [MARQUEUR]
+```
+
+> Disponible seulement si l'URL du registre Docker a été défini via la variable d'environnement
+> `KANO_DOCKER_REGISTRY` et que l'utilisateur s'y est connecté via `docker login` au préalable.
+> Les options usuelles de `docker image pull` peuvent être utilisées
+
+#### image push
+
+Pour téléverser une image de travail au registre :
+
+```shell
+kano docker image push [OPTIONS] [MARQUEUR]
+
+# ou
+
+kano docker push [OPTIONS] [MARQUEUR]
+```
+
+> Disponible seulement si l'URL du registre Docker a été défini via la variable d'environnement
+> `KANO_DOCKER_REGISTRY` et que l'utilisateur s'y est connecté via `docker login` au préalable.
+> Les options usuelles de `docker image push` peuvent être utilisées
+
+### Conteneur
+
+Le conteneur de développement est créé à partir de l'image de travail et est éphémère. Par souci
+de productivité, il est conçu pour être réutilisable, mais supprimé lorsqu'arrêté. Le conteneur
+peut être personnalisé en montant différents répertoires, fichiers et variables d'environnement
+de l'hôte. On peut interagir avec lui simplement depuis la ligne de commande, ou en y attachant
+un éditeur/EDI pour plus de productivité
+
+#### container create
+
+Pour créer un conteneur depuis l'image de travail :
+
+```shell
+kano docker container create [OPTIONS]
+
+# ou
+
+kano docker create [OPTIONS]
+```
+
+> Les options usuelles de `docker container create` peuvent être utilisées
+
+Par défaut, ce conteneur sera nommé `${PROJECT_NAME}-dev-container`. Son nom peut être
+personnalisé via la variable d'environnement `KANO_DOCKER_CONTAINER` (préférablement dans le
+fichier `.kano/environment` du projet). De plus, ce conteneur :
+
+- Sera éphémère
+- Sera Non-interactif
+- Ne créera pas fichiers de journalisation
+- Montera le répertoire du projet en tant que volume
+- Définira le répertoire du projet en tant que répertoire courant
+- Aura un utilisateur _sudo_ sans mot de passe avec le même nom et répertoire personnel que
+  l'utilisateur hôte
+- Définira la variable d'environnement `KANO_DOCKER` à `true`
+
+#### container rm
+
+Pour supprimer le conteneur créé avant son démarrage :
+
+```shell
+kano docker container rm [OPTIONS]
+
+# ou
+
+kano docker rm [OPTIONS]
+```
+
+> Les options usuelles de `docker container rm` peuvent être utilisées
+
+#### container start
+
+Pour démarrer le conteneur créé :
+
+```shell
+kano docker container start [OPTIONS]
+
+# ou
+
 kano docker start [OPTIONS]
 ```
 
-> Les options usuelles de `docker run` peuvent être utilisées
+> Les options usuelles de `docker container start` peuvent être utilisées
 
-Par défaut, ce conteneur:
+#### container exec
 
-- Sera nommé `${PROJECT_NAME}-dev-container`
-- Sera interactif
-- Sera non-persistent
-- Ne créera pas de fichiers de log
-- Aura le répertoire du projet embarqué comme volume
-- Aura le répertoire du projet configuré comme répertoire de travail
-
-> Le nom du conteneur peut être personnalisé via la variable d'environnement
-> `KANO_DEVELOPMENT_CONTAINER` dans le fichier `.kano/environment` du projet
-
-### Stop
-
-Pour arrêter le conteneur de développement en arrière-plan :
+Pour exécuter une commande à l'intérieur du conteneur en marche :
 
 ```shell
-kano docker stop
+kano docker container exec [OPTIONS] COMMANDE
+
+# ou
+
+kano docker exec [OPTIONS] COMMANDE
 ```
 
-### Attach
+> Les options usuelles de `docker container exec` peuvent être utilisées
 
-Pour s'attacher au conteneur de développement en arrière-plan :
+#### container stop
+
+Pour arrêter et supprimer le conteneur en marche :
 
 ```shell
-kano docker attach
+kano docker container stop [OPTIONS]
+
+# ou
+
+kano docker stop [OPTIONS]
 ```
 
-> Les options usuelles de `docker attach` peuvent être utilisées
+> Les options usuelles de `docker container stop` peuvent être utilisées
 
-Une fois attaché, pour quitter le conteneur :
+### Raccourcis
+
+`kano docker` offre des sous-commandes additionnelles, qui n'ont pas d'homologues natives dans
+l'ILC `docker`, mais qui aident à augmenter la productivité
+
+#### boot
+
+Pour s'assurer qu'un conteneur de développement est en marche :
 
 ```shell
-exit
+kano docker boot
 ```
 
-### Enter
+- Si l'image de développement n'existe pas, elle sera bâtie, à moins que `KANO_DOCKER_TAG` ne
+  soit définie. Dans le cas échéant, l'image sera téléchargée depuis le registre défini par
+  `KANO_DOCKER_REGISTRY`
+- Si le conteneur de développement n'existe pas, il sera créé
+- Si le conteneur de développement n'est pas en marche, il sera démarré
 
-Pour démarrer ([start](###start)) et s'attacher ([attach](###attach)) d'un coup:
+#### execute
+
+Pour exécuter une commande dans un conteneur de développement :
 
 ```shell
-kano docker enter
+kano docker execute [OPTIONS] COMMANDE
 ```
+
+- `kano docker boot` sera appelé
+- La commande sera ensuite passée à `kano docker container exec`
+
+> Les options de `docker container exec` peuvent être utilisées
+
+#### shell
+
+Pour ouvrir une interface système interactive dans un conteneur de développement :
+
+```shell
+kano docker shell
+```
+
+- `kano docker execute` sera appelé avec la même interface système définie par la variable
+  d'environnement `SHELL` de l'utilisateur hôte, ou `/bin/sh` si elle n'est pas définie
+
+> Astuce: pour fermer l'interface système et retourner à l'hôte, simplement utiliser la commande
+> `exit`
+
+#### clean
+
+Pour effacer toutes traces de l'image et du conteneur de développement pour le project courant :
+
+```shell
+kano docker clean
+```
+
+- Si le conteneur de développement est en marche, il sera arrêté et supprimé
+- Si le conteneur de développement existe mais n'est pas en marche, il sera supprimé
+- Si l'image de développement existe, elle sera supprimée
+
+## Exemples
+
+### Processus de travail
+
+Bâtir l'image, créer et démarrer le conteneur puis y attacher
+[Visual Studio Code](https://code.visualstudio.com) en utilisant l'extension
+[Remote - Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+:
+
+```shell
+kano docker boot
+# Ouvrir la palette de commandes dans VS Code
+# Sélectionner "Remote - Containers: Attach to Running Container..."
+# Sélectionner le conteneur de développement du projet
+```
+
+Ouvir une interface système dans ce même conteneur :
+
+```shell
+kano docker shell
+```
+
+Ouvir une autre interface système dans ce même conteneur :
+
+```shell
+# Dans un autre terminal
+kano docker shell
+```
+
+Exécuter une commande dans ce même conteneur :
+
+```shell
+kano docker execute une_commande
+```
+
+Arrêter et supprimer le conteneur puis l'image :
+
+```shell
+kano docker clean
+```
+
+#### Configuration Visual Studio Code
+
+Par défaut, l'extension essait d'installer son serveur distant dans le conteneur en tant que
+`root`. Si l'utilisateur par défaut de l'image de développement n'est pas `root` (bonne
+pratique), cette opération échouera. Pour corriger ce comportement, un fichier de configuration
+définissant le bon utilisateur à utiliser pour ce conteneur doit être créé. Ce fichier ne doit
+être créé qu'une seule fois par projet, à moins que le nom du conteneur change.
+[Cette tâche kano](/templates/vscode/tasks/configure_vscode) peut être utilisée pour le générer
+automatiquement
+
+### Personnaliser le conteneur de développement
+
+Le conteneur de développement peut être personnalisé en utilisant des volumes, des variables
+d'environnement et plus encore. Le cas d'usage le plus commun serait de répliquer des
+configurations de développement personnelles présente sur l'hôte afin d'augmenter la
+productivité une fois connecté au conteneur. Les sections suivantes se concentreront sur ce cas
+particulier
+
+#### Configurer les personnalisations
+
+La manière la plus simple de configurer le conteneur est de le créer en utilisant des options
+`docker` standard. Par exemple, pour monter un profile d'interface système et une configuration
+`git`, simplement créer un conteneur avec les options appropriées :
+
+```shell
+kano docker container create \
+  --volume $HOME/.profile:$HOME/.profile \
+  --volume $HOME/.gitconfig:$HOME/.gitconfig \
+  --volume $HOME/.gitignore_global:$HOME/.gitignore_global
+```
+
+Bien qu'utile, entrer manuellement toutes les options désirées à chaque fois qu'un conteneur est
+créé pourrait s'avérer fastidieux. De plus, plusieurs [raccourcis](#raccourcis) n'en tiendront
+pas compte. Le meilleur moyen de configurer ces personnalisations est d'utiliser une tâche kano
+utilisateur procuratoire, aussi nommée `docker`. Cette tâche devrait avoir la forme suivante :
+
+```shell
+#!/bin/sh
+
+docker_help() {
+  echo "Proxies the builtin docker task with my personal configurations"
+}
+
+docker() {
+  # shellcheck disable=SC2046
+  kano --next docker $(_insert_my_personal_docker_options "$@" | xargs)
+}
+
+_insert_my_personal_docker_options() {
+  if [ "$1" = "container" ]; then
+    echo "$1" && shift
+  fi
+
+  if [ "$1" = "create" ]; then
+    echo "$1" && shift
+    _echo_my_container_create_options
+  fi
+
+  echo "$@"
+}
+
+_echo_my_container_create_options() {
+  echo "--volume $HOME/.profile:$HOME/.profile"
+  echo "--volume $HOME/.gitconfig:$HOME/.gitconfig"
+  echo "--volume $HOME/.gitignore_global:$HOME/.gitignore_global"
+}
+```
+
+> La procuration est rendue possible par l'option `--next` qui délègue l'exécution de la tâche à
+> la portée suivante. Pour plus d'information sur les options, voir
+> [ceci](/docs/fr/usage.md##scopes)
+
+Avec une telle tâche utilisateur, tous les conteneurs créés par `kano docker container create`,
+incluant les [raccourcis](#raccourcis), incluront maintenant le profile d'interface système et
+la configuration `git` de l'utilisateur hôte. Le même principe pourrait être appliqué avec une
+tâche d'équipe pour des configurations communes d'équipe, ou directement dans le projet pour des
+configurations spécifiques au projet, comme un nom de réseau local particulier ou des ports à
+exposer
+
+#### Exemples de personnalisations
+
+Un utilisateur pourrait vouloir configurer plusieurs types de personnalisations. Les
+sous-sections suivantes en présentent quelques exemples
+
+##### TERM
+
+Pour avoir les mêmes couleurs de terminal que sur l'hôte :
+
+```shell
+--env TERM="$TERM"
+```
+
+##### bash
+
+Pour avoir la même configuration `bash` que sur l'hôte :
+
+```shell
+--volume "$HOME/.bashrc:$HOME/.bashrc"
+```
+
+> `bash` doit aussi être installé dans l'image de développement
+
+##### zsh
+
+Pour avoir la même configuration `zsh` que sur l'hôte :
+
+```shell
+--volume "$HOME/.zshenv:$HOME/.zshenv"
+--volume "$HOME/.zshrc:$HOME/.zshrc"
+```
+
+> `zsh` doit aussi être installé dans l'image de développement
+
+##### git
+
+Pour avoir la même configuration `git` que sur l'hôte :
+
+```shell
+--volume "$HOME/.gitconfig:$HOME/.gitconfig"
+--volume "$HOME/.gitignore_global:$HOME/.gitignore_global"
+```
+
+> `git` doit aussi être installé dans l'image de développement
+
+##### vim
+
+Pour avoir la même configuration `vim` que sur l'hôte :
+
+```shell
+--volume "$HOME/.vim:$HOME/.vim"
+--volume "$HOME/.vimrc:$HOME/.vimrc"
+--env EDITOR="/usr/bin/vim"
+```
+
+> `vim` doit aussi être installé dans l'image de développement
+
+##### ssh
+
+Pour avoir la même configuration `ssh` que sur l'hôte :
+
+```shell
+--volume "$HOME/.ssh:$HOME/.ssh"
+--volume "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
+--env SSH_AUTH_SOCK="$SSH_AUTH_SOCK"
+```
+
+Cela relaiera l'agent `ssh` de l'hôte dans le conteneur de développement
+
+> `ssh-client` doit aussi être installé dans l'image de développement
+
+###### ssh et macOS
+
+Si _macOS Keychain_ est utilisé pour gérer les phrases secrètes `ssh`, monter la configuration
+`ssh` de l'hôte ne fonctionnera pas directement puisque _Keychain_ ne sera pas accessible depuis
+le conteneur. Pour pallier à cette situation, la configuration suivante peut être ajoutée à
+`$HOME/.ssh/config` pour demander la phrase secrète une fois par session si _Keychain_ n'est pas
+trouvé :
+
+```text
+IgnoreUnknown UseKeychain
+UseKeychain yes
+AddKeysToAgent yes
+```
+
+##### gpg
+
+Bien qu'il soit possible d'avoir `gnupg2` installé dans le conteneur et la configuration `gpg`
+de l'hôte montée, aucun moyen n'a encore été trouvé pour correctement partager des clés `gpg`
+avec le conteneur qui fonctionne tant sur Linux que sur macOS. Ceci est grandement dû au fait
+que
+[_Docker for Mac_ ne supportera pas le montage de socket unix](https://github.com/docker/for-mac/issues/483),
+et donc le montage du socket GPG. Une solution palliative avec l'impact le plus minimal sur la
+productivité est de simplement utliser `gpg` en dehors du conteneur lorsque les clés de
+l'utilisateur hôte sont requises, pour par exemple signer des commits ou des marqueurs git

--- a/docs/fr/tasks/docker.md
+++ b/docs/fr/tasks/docker.md
@@ -224,7 +224,19 @@ kano docker container stop [OPTIONS]
 kano docker stop [OPTIONS]
 ```
 
-> Les options usuelles de `docker container stop` peuvent être utilisées
+#### container kill
+
+Pour terminer et supprimer le conteneur en marche :
+
+```shell
+kano docker container kill [OPTIONS]
+
+# ou
+
+kano docker kill [OPTIONS]
+```
+
+> Les options usuelles de `docker container kill` peuvent être utilisées
 
 ### Raccourcis
 

--- a/docs/fr/tasks/dockered.md
+++ b/docs/fr/tasks/dockered.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Utiliser la tâche `dockered` pour exécuter une tâche dans un conteneur de développement éphémère
+Utiliser la tâche `dockered` pour exécuter une tâche dans un conteneur de développement
 
 ## Usage
 
@@ -14,12 +14,13 @@ Pour exécuter une tâche dans un conteneur de développement :
 kano dockered TÂCHE
 ```
 
-> `kano` doit aussi être installé dans l'image de développement
+> `kano` doit aussi être installé dans l'image de développement (jusqu'à ce que la
+> fonctionnalité d'auto-montage soit implémentée)
 
 ### Note
 
 Cette tâche utilise la tâche [docker](/docs/fr/tasks/docker.md) et est un équivalent à :
 
 ```shell
-kano docker run kano TÂCHE
+kano docker execute kano TÂCHE
 ```

--- a/docs/fr/tasks/init.md
+++ b/docs/fr/tasks/init.md
@@ -9,9 +9,9 @@ Utiliser la tâche `init` pour créer des tâches et des répertoires kano
 ## Usage
 
 ```text
-kano init NIVEAU GABARIT [DETAILS_GABARIT]
+kano init PORTÉE GABARIT [DETAILS_GABARIT]
 
-NIVEAU: project | user | team | system
+PORTÉE: project | user | team | system
 GABARIT: directory | task
 DETAILS_GABARIT: nom de tâche pour le gabarit task
 ```

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_directory_exist"
 . "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_file_exist"
 . "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
 
@@ -9,7 +8,7 @@ docker_help() {
 }
 
 docker() {
-  if [ -n "$KANO_DOCKER" ] && "$KANO_DOCKER"; then
+  if [ "$KANO_DOCKER" = true ]; then
     fail "Cannot run docker task inside a development container"
   fi
 
@@ -19,6 +18,10 @@ docker() {
 
   _ensure_docker_daemon_is_running
 
+  if [ -z "$KANO_DOCKER_FILE" ]; then
+    export KANO_DOCKER_FILE="$KANO_PROJECT_DIRECTORY/Dockerfile"
+  fi
+
   if [ -z "$KANO_DOCKER_IMAGE" ]; then
     export KANO_DOCKER_IMAGE="$KANO_PROJECT_NAME-dev"
   fi
@@ -27,22 +30,52 @@ docker() {
     export KANO_DOCKER_CONTAINER="$KANO_PROJECT_NAME-dev-container"
   fi
 
+  if [ -z "$KANO_DOCKER_TAG" ]; then
+    export KANO_DOCKER_TAG="latest"
+  fi
+
+  if [ -n "$KANO_DOCKER_REGISTRY" ]; then
+    WORKING_IMAGE="$KANO_DOCKER_REGISTRY/$KANO_DOCKER_IMAGE:$KANO_DOCKER_TAG"
+
+  else
+    WORKING_IMAGE="$KANO_DOCKER_IMAGE:$KANO_DOCKER_TAG"
+  fi
+
   image() {
     build() {
-      if ! does_directory_exist "$KANO_PROJECT_DIRECTORY"; then
-        fail "No kano directory exists in project"
+      if [ "$KANO_DOCKER_TAG" != "latest" ]; then
+        # shellcheck disable=SC2116
+        fail "$(
+          echo \
+            "Cannot rebuild a versioned image. Run 'kano docker pull $KANO_DOCKER_TAG' or" \
+            "unset 'KANO_DOCKER_TAG' environment variable"
+        )"
       fi
 
-      if ! does_file_exist "$KANO_PROJECT_DIRECTORY/Dockerfile"; then
-        fail "No Dockerfile in project kano directory"
+      if ! does_file_exist "$KANO_DOCKER_FILE"; then
+        # shellcheck disable=SC2116
+        fail "$(
+          echo \
+            "No Dockerfile at '$KANO_DOCKER_FILE'. Create one or set 'KANO_DOCKER_FILE'" \
+            "environment variable to configure a different location"
+        )"
       fi
 
-      # shellcheck disable=SC2046
-      _docker image build \
-        --file "$KANO_PROJECT_DIRECTORY/Dockerfile" \
-        --tag "$KANO_DOCKER_IMAGE" \
-        $(_does_image_exist && echo "--cache-from $KANO_DOCKER_IMAGE") \
-        "$@" .
+      if [ -n "$KANO_DOCKER_REGISTRY" ]; then
+        _docker image build \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          --cache-from "$WORKING_IMAGE" \
+          --file "$KANO_DOCKER_FILE" \
+          --pull \
+          --tag "$WORKING_IMAGE" \
+          "$@" .
+
+      else
+        _docker image build \
+          --file "$KANO_DOCKER_FILE" \
+          --tag "$WORKING_IMAGE" \
+          "$@" .
+      fi
     }
 
     rm() {
@@ -50,7 +83,35 @@ docker() {
         fail "Development image does not exist"
       fi
 
-      _docker image rm "$@" "$KANO_DOCKER_IMAGE"
+      _docker image rm "$@" "$WORKING_IMAGE"
+    }
+
+    pull() {
+      if [ -z "$KANO_DOCKER_REGISTRY" ]; then
+        fail "No container registry configured. Set 'KANO_DOCKER_REGISTRY' environment variable"
+      fi
+
+      # shellcheck disable=SC2046
+      _docker image pull $(_insert_image_in_push_or_pull_arguments "$@" | xargs)
+    }
+
+    push() {
+      if [ -z "$KANO_DOCKER_REGISTRY" ]; then
+        fail "No container registry configured. Set 'KANO_DOCKER_REGISTRY' environment variable"
+      fi
+
+      # shellcheck disable=SC2046
+      _docker image push $(_insert_image_in_push_or_pull_arguments "$@" | xargs)
+    }
+
+    tag() {
+      TAG="$1"
+
+      if [ -z "$TAG" ]; then
+        fail "No tag provided"
+      fi
+
+      _docker image tag "$WORKING_IMAGE" "$(echo "$WORKING_IMAGE" | cut -d ":" -f 1):$TAG"
     }
 
     "$@"
@@ -68,9 +129,22 @@ docker() {
 
       USER_ID="$(id -u)"
       USER_NAME="$(id -un)"
+      # shellcheck disable=SC2116
+      START_COMMAND="$(
+        echo \
+          "/bin/sh -c" \
+          "sudo useradd" \
+          "--uid $USER_ID --gid sudo --no-create-home --home-dir $HOME $USER_NAME;" \
+          "sudo passwd --delete $USER_NAME > /dev/null;" \
+          "sudo chown -R $USER_NAME $HOME;" \
+          "sh -c 'kill -STOP \$\$'"
+      )"
       _docker container create \
         --env KANO_DOCKER=true \
+        --env KANO_DOCKER_FILE \
+        --env KANO_DOCKER_REGISTRY \
         --env KANO_DOCKER_IMAGE \
+        --env KANO_DOCKER_TAG \
         --env KANO_DOCKER_CONTAINER \
         --log-driver none \
         --name "$KANO_DOCKER_CONTAINER" \
@@ -78,12 +152,8 @@ docker() {
         --volume "$PWD:$PWD" \
         --workdir "$PWD" \
         "$@" \
-        "$KANO_DOCKER_IMAGE" \
-        /bin/sh -c "\
-sudo useradd --uid $USER_ID --gid sudo --no-create-home --home-dir $HOME $USER_NAME; \
-sudo passwd --delete $USER_NAME > /dev/null; \
-sudo chown -R $USER_NAME $HOME; \
-sh -c 'kill -STOP \$\$'"
+        "$WORKING_IMAGE" \
+        "$START_COMMAND"
     }
 
     rm() {
@@ -157,6 +227,18 @@ sh -c 'kill -STOP \$\$'"
     image rm "$@"
   }
 
+  pull() {
+    image pull "$@"
+  }
+
+  push() {
+    image push "$@"
+  }
+
+  tag() {
+    image tag "$@"
+  }
+
   create() {
     container create "$@"
   }
@@ -208,7 +290,7 @@ sh -c 'kill -STOP \$\$'"
       _kano docker container start
     fi
 
-    _kano docker container exec_ --interactive --tty "$SHELL" --login
+    _kano docker container exec_ --interactive --tty "${SHELL:-/bin/sh}" --login
   }
 
   clean() {
@@ -232,6 +314,30 @@ sh -c 'kill -STOP \$\$'"
   else
     "$@"
   fi
+}
+
+_insert_image_in_push_or_pull_arguments() {
+  IS_EXPECTING_OPTION_VALUE=false
+  for ARGUMENT in "$@"; do
+    if _is_image_push_or_pull_flag "$ARGUMENT"; then
+      echo "$ARGUMENT"
+
+    elif _is_flag_or_option "$ARGUMENT"; then
+      IS_EXPECTING_OPTION_VALUE=true
+      echo "$ARGUMENT"
+
+    elif $IS_EXPECTING_OPTION_VALUE; then
+      IS_EXPECTING_OPTION_VALUE=false
+      echo "$ARGUMENT"
+
+    else
+      TAG="$ARGUMENT"
+      echo "$(echo "$WORKING_IMAGE" | cut -d ":" -f 1):$TAG"
+      return
+    fi
+  done
+
+  echo "$WORKING_IMAGE"
 }
 
 _insert_container_in_exec_arguments() {
@@ -266,6 +372,23 @@ _insert_container_in_exec_arguments() {
   done
 }
 
+_is_image_push_or_pull_flag() {
+  case "$1" in
+    --all-tags | \
+      -a* | \
+      --disable-content-trust | \
+      --help | \
+      --quiet | \
+      -q*)
+      true
+      ;;
+
+    *)
+      false
+      ;;
+  esac
+}
+
 _is_container_exec_flag() {
   case "$1" in
     --detach | \
@@ -285,7 +408,7 @@ _is_container_exec_flag() {
   esac
 }
 
- _is_flag_or_option() {
+_is_flag_or_option() {
   case "$1" in
     -*)
       true
@@ -306,7 +429,7 @@ _ensure_docker_daemon_is_running() {
 }
 
 _does_image_exist() {
-  [ -n "$(_docker image ls --quiet --filter reference="$KANO_DOCKER_IMAGE")" ]
+  [ -n "$(_docker image ls --quiet --filter reference="$WORKING_IMAGE")" ]
 }
 
 _does_container_exist() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -192,6 +192,18 @@ docker() {
       _docker container stop "$@" "$KANO_DOCKER_CONTAINER"
     }
 
+    kill_() {
+      if ! _does_container_exist; then
+        fail "Development container does not exist"
+      fi
+
+      if ! _is_container_running; then
+        fail "Development container is not running"
+      fi
+
+      _docker container 'kill' "$@" "$KANO_DOCKER_CONTAINER"
+    }
+
     exec_() {
       if ! _does_container_exist; then
         fail "Development container does not exist. Run 'kano docker container create'"
@@ -208,13 +220,17 @@ docker() {
         $(_insert_container_in_exec_arguments "$@" | xargs)
     }
 
-    if [ "$1" = "exec" ]; then
-      shift
-      exec_ "$@"
+    case "$1" in
+      exec | kill)
+        SUBCOMMAND="${1}_"
+        shift
+        "$SUBCOMMAND" "$@"
+        ;;
 
-    else
-      "$@"
-    fi
+      *)
+        "$@"
+        ;;
+    esac
   }
 
   # Native Docker shortcuts
@@ -255,6 +271,10 @@ docker() {
     container stop "$@"
   }
 
+  kill_() {
+    container kill_ "$@"
+  }
+
   exec_() {
     container exec_ "$@"
   }
@@ -286,7 +306,7 @@ docker() {
 
   clean() {
     if _is_container_running; then
-      _kano docker container stop
+      _kano docker container 'kill'
     fi
 
     if _does_container_exist; then
@@ -298,13 +318,17 @@ docker() {
     fi
   }
 
-  if [ "$1" = "exec" ]; then
-    shift
-    exec_ "$@"
+  case "$1" in
+    exec | kill)
+      SUBCOMMAND="${1}_"
+      shift
+      "$SUBCOMMAND" "$@"
+      ;;
 
-  else
-    "$@"
-  fi
+    *)
+      "$@"
+      ;;
+  esac
 }
 
 _insert_image_in_push_or_pull_arguments() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -261,7 +261,7 @@ docker() {
 
   # kano docker shortcuts
 
-  execute() {
+  boot() {
     if ! _does_image_exist; then
       _kano docker image build
     fi
@@ -273,24 +273,15 @@ docker() {
     if ! _is_container_running; then
       _kano docker container start
     fi
+  }
 
+  execute() {
+    _kano docker boot
     _kano docker container exec_ "$@"
   }
 
   shell() {
-    if ! _does_image_exist; then
-      _kano docker image build
-    fi
-
-    if ! _does_container_exist; then
-      _kano docker container create
-    fi
-
-    if ! _is_container_running; then
-      _kano docker container start
-    fi
-
-    _kano docker container exec_ --interactive --tty "${SHELL:-/bin/sh}" --login
+    _kano docker execute --interactive --tty "${SHELL:-/bin/sh}" --login
   }
 
   clean() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -181,47 +181,47 @@ sh -c 'kill -STOP \$\$'"
 
   execute() {
     if ! _does_image_exist; then
-      kano docker image build
+      _kano docker image build
     fi
 
     if ! _does_container_exist; then
-      kano docker container create
+      _kano docker container create
     fi
 
     if ! _is_container_running; then
-      kano docker container start
+      _kano docker container start
     fi
 
-    kano docker container exec_ "$@"
+    _kano docker container exec_ "$@"
   }
 
   shell() {
     if ! _does_image_exist; then
-      kano docker image build
+      _kano docker image build
     fi
 
     if ! _does_container_exist; then
-      kano docker container create
+      _kano docker container create
     fi
 
     if ! _is_container_running; then
-      kano docker container start
+      _kano docker container start
     fi
 
-    kano docker container exec_ --interactive --tty "$SHELL" --login
+    _kano docker container exec_ --interactive --tty "$SHELL" --login
   }
 
   clean() {
     if _is_container_running; then
-      kano docker container stop
+      _kano docker container stop
     fi
 
     if _does_container_exist; then
-      kano docker container rm
+      _kano docker container rm
     fi
 
     if _does_image_exist; then
-      kano docker image rm
+      _kano docker image rm
     fi
   }
 
@@ -315,6 +315,10 @@ _does_container_exist() {
 
 _is_container_running() {
   [ -n "$(_docker container ls --quiet --filter name="$KANO_DOCKER_CONTAINER")" ]
+}
+
+_kano() {
+  command kano "$@"
 }
 
 _docker() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -66,24 +66,24 @@ docker() {
         fail "Development container already exists"
       fi
 
+      USER_ID="$(id -u)"
+      USER_NAME="$(id -un)"
       _docker container create \
         --env KANO_DOCKER=true \
         --env KANO_DOCKER_IMAGE \
         --env KANO_DOCKER_CONTAINER \
-        --interactive \
         --log-driver none \
         --name "$KANO_DOCKER_CONTAINER" \
         --rm \
-        --tty \
         --volume "$PWD:$PWD" \
         --workdir "$PWD" \
         "$@" \
         "$KANO_DOCKER_IMAGE" \
         /bin/sh -c "\
-sudo useradd --uid $(id -u) --gid sudo --home-dir $HOME $(id -un); \
-sudo passwd --delete $(id -un) > /dev/null; \
-echo \"Press ENTER to exit\"; \
-read -r _;"
+sudo useradd --uid $USER_ID --gid sudo --no-create-home --home-dir $HOME --shell $SHELL $USER_NAME; \
+sudo passwd --delete $USER_NAME > /dev/null; \
+sudo chown -R $USER_NAME $HOME; \
+sh -c 'kill -STOP \$\$'"
     }
 
     rm() {
@@ -131,22 +131,23 @@ read -r _;"
         fail "Development container is not running. Run 'kano docker container start'"
       fi
 
-      _docker container exec \
-        --interactive \
-        --tty \
+      # shellcheck disable=SC2046
+      _docker container 'exec' \
         --user "$(id -un)" \
         --workdir "$PWD" \
-        "$KANO_DOCKER_CONTAINER" \
-        "$@"
+        $(_insert_container_in_exec_arguments "$@" | xargs)
     }
 
     if [ "$1" = "exec" ]; then
       shift
       exec_ "$@"
+
     else
       "$@"
     fi
   }
+
+  # Native Docker shortcuts
 
   build() {
     image build "$@"
@@ -176,6 +177,8 @@ read -r _;"
     container exec_ "$@"
   }
 
+  # kano docker shortcuts
+
   execute() {
     if ! _does_image_exist; then
       kano docker image build
@@ -193,7 +196,19 @@ read -r _;"
   }
 
   shell() {
-    execute "$SHELL" --login
+    if ! _does_image_exist; then
+      kano docker image build
+    fi
+
+    if ! _does_container_exist; then
+      kano docker container create
+    fi
+
+    if ! _is_container_running; then
+      kano docker container start
+    fi
+
+    kano docker container exec_ --interactive --tty "$SHELL" --login
   }
 
   clean() {
@@ -213,9 +228,73 @@ read -r _;"
   if [ "$1" = "exec" ]; then
     shift
     exec_ "$@"
+
   else
     "$@"
   fi
+}
+
+_insert_container_in_exec_arguments() {
+  IS_CONTAINER_INSERTED=false
+  IS_EXPECTING_OPTION_VALUE=false
+  for ARGUMENT in "$@"; do
+    if $IS_CONTAINER_INSERTED; then
+      echo "$ARGUMENT"
+      continue
+    fi
+
+    if _is_container_exec_flag "$ARGUMENT"; then
+      echo "$ARGUMENT"
+      continue
+    fi
+
+    if _is_flag_or_option "$ARGUMENT"; then
+      IS_EXPECTING_OPTION_VALUE=true
+      echo "$ARGUMENT"
+      continue
+    fi
+
+    if $IS_EXPECTING_OPTION_VALUE; then
+      IS_EXPECTING_OPTION_VALUE=false
+
+    else
+      echo "$KANO_DOCKER_CONTAINER"
+      IS_CONTAINER_INSERTED=true
+    fi
+
+    echo "$ARGUMENT"
+  done
+}
+
+_is_container_exec_flag() {
+  case "$1" in
+    --detach | \
+      -d* | \
+      --help | \
+      --interactive | \
+      -i* | \
+      --privileged | \
+      --tty | \
+      -t*)
+      true
+      ;;
+
+    *)
+      false
+      ;;
+  esac
+}
+
+ _is_flag_or_option() {
+  case "$1" in
+    -*)
+      true
+      ;;
+
+    *)
+      false
+      ;;
+  esac
 }
 
 _is_docker_installed() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -190,6 +190,7 @@ docker() {
       fi
 
       _docker container stop "$@" "$KANO_DOCKER_CONTAINER"
+      _docker container 'wait' "$KANO_DOCKER_CONTAINER" > /dev/null
     }
 
     kill_() {
@@ -202,6 +203,7 @@ docker() {
       fi
 
       _docker container 'kill' "$@" "$KANO_DOCKER_CONTAINER"
+      _docker container 'wait' "$KANO_DOCKER_CONTAINER" > /dev/null
     }
 
     exec_() {
@@ -283,7 +285,12 @@ docker() {
 
   boot() {
     if ! _does_image_exist; then
-      _kano docker image build
+      if [ "$KANO_DOCKER_TAG" = "latest" ]; then
+        _kano docker image build
+
+      else
+        _kano docker image pull
+      fi
     fi
 
     if ! _does_container_exist; then
@@ -444,15 +451,15 @@ _ensure_docker_daemon_is_running() {
 }
 
 _does_image_exist() {
-  [ -n "$(_docker image ls --quiet --filter reference="$WORKING_IMAGE")" ]
+  [ -n "$(_docker image ls --quiet --filter reference="$WORKING_IMAGE" | xargs)" ]
 }
 
 _does_container_exist() {
-  [ -n "$(_docker container ls --all --quiet --filter name="$KANO_DOCKER_CONTAINER")" ]
+  [ -n "$(_docker container ls --all --quiet --filter name="$KANO_DOCKER_CONTAINER" | xargs)" ]
 }
 
 _is_container_running() {
-  [ -n "$(_docker container ls --quiet --filter name="$KANO_DOCKER_CONTAINER")" ]
+  [ -n "$(_docker container ls --quiet --filter name="$KANO_DOCKER_CONTAINER" | xargs)" ]
 }
 
 _kano() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -130,15 +130,15 @@ docker() {
       USER_ID="$(id -u)"
       USER_NAME="$(id -un)"
       # shellcheck disable=SC2116
-      START_COMMAND="$(
+      INITIALIZATION_SCRIPT="$(
         echo \
-          "/bin/sh -c" \
           "sudo useradd" \
           "--uid $USER_ID --gid sudo --no-create-home --home-dir $HOME $USER_NAME;" \
           "sudo passwd --delete $USER_NAME > /dev/null;" \
-          "sudo chown -R $USER_NAME $HOME || true;" \
+          "sudo chown -R $USER_NAME $HOME;" \
           "sh -c 'kill -STOP \$\$'"
       )"
+
       _docker container create \
         --env KANO_DOCKER=true \
         --env KANO_DOCKER_FILE \
@@ -153,7 +153,7 @@ docker() {
         --workdir "$PWD" \
         "$@" \
         "$WORKING_IMAGE" \
-        "$START_COMMAND"
+        /bin/sh -c "$INITIALIZATION_SCRIPT"
     }
 
     rm() {

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -136,7 +136,7 @@ docker() {
           "sudo useradd" \
           "--uid $USER_ID --gid sudo --no-create-home --home-dir $HOME $USER_NAME;" \
           "sudo passwd --delete $USER_NAME > /dev/null;" \
-          "sudo chown -R $USER_NAME $HOME;" \
+          "sudo chown -R $USER_NAME $HOME || true;" \
           "sh -c 'kill -STOP \$\$'"
       )"
       _docker container create \

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -80,7 +80,7 @@ docker() {
         "$@" \
         "$KANO_DOCKER_IMAGE" \
         /bin/sh -c "\
-sudo useradd --uid $USER_ID --gid sudo --no-create-home --home-dir $HOME --shell $SHELL $USER_NAME; \
+sudo useradd --uid $USER_ID --gid sudo --no-create-home --home-dir $HOME $USER_NAME; \
 sudo passwd --delete $USER_NAME > /dev/null; \
 sudo chown -R $USER_NAME $HOME; \
 sh -c 'kill -STOP \$\$'"

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -5,27 +5,11 @@
 . "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
 
 docker_help() {
-  echo "Work in an isolated development docker container"
+  echo "Develop in a docker container"
 }
 
 docker() {
-  if [ -z "$KANO_DEVELOPMENT_IMAGE" ]; then
-    export KANO_DEVELOPMENT_IMAGE="$KANO_PROJECT_NAME-dev"
-  fi
-
-  if [ -z "$KANO_DEVELOPMENT_CONTAINER" ]; then
-    export KANO_DEVELOPMENT_CONTAINER="$KANO_PROJECT_NAME-dev-container"
-  fi
-
-  if ! does_directory_exist "$KANO_PROJECT_DIRECTORY"; then
-    fail "No kano directory exists in project"
-  fi
-
-  if ! does_file_exist "$KANO_PROJECT_DIRECTORY/Dockerfile"; then
-    fail "No Dockerfile in project kano directory"
-  fi
-
-  if [ -n "$KANO_IS_IN_DOCKER" ] && "$KANO_IS_IN_DOCKER"; then
+  if [ -n "$KANO_DOCKER" ] && "$KANO_DOCKER"; then
     fail "Cannot run docker task inside a development container"
   fi
 
@@ -35,146 +19,203 @@ docker() {
 
   _ensure_docker_daemon_is_running
 
-  build() {
-    if _does_development_image_exist; then
-      _docker_build --cache-from "$KANO_DEVELOPMENT_IMAGE" "$@"
+  if [ -z "$KANO_DOCKER_IMAGE" ]; then
+    export KANO_DOCKER_IMAGE="$KANO_PROJECT_NAME-dev"
+  fi
 
+  if [ -z "$KANO_DOCKER_CONTAINER" ]; then
+    export KANO_DOCKER_CONTAINER="$KANO_PROJECT_NAME-dev-container"
+  fi
+
+  image() {
+    build() {
+      if ! does_directory_exist "$KANO_PROJECT_DIRECTORY"; then
+        fail "No kano directory exists in project"
+      fi
+
+      if ! does_file_exist "$KANO_PROJECT_DIRECTORY/Dockerfile"; then
+        fail "No Dockerfile in project kano directory"
+      fi
+
+      # shellcheck disable=SC2046
+      _docker image build \
+        --file "$KANO_PROJECT_DIRECTORY/Dockerfile" \
+        --tag "$KANO_DOCKER_IMAGE" \
+        $(_does_image_exist && echo "--cache-from $KANO_DOCKER_IMAGE") \
+        "$@" .
+    }
+
+    rm() {
+      if ! _does_image_exist; then
+        fail "Development image does not exist"
+      fi
+
+      _docker image rm "$@" "$KANO_DOCKER_IMAGE"
+    }
+
+    "$@"
+  }
+
+  container() {
+    create() {
+      if ! _does_image_exist; then
+        fail "Development image does not exist. Run 'kano docker image build'"
+      fi
+
+      if _does_container_exist; then
+        fail "Development container already exists"
+      fi
+
+      _docker container create \
+        --env KANO_DOCKER=true \
+        --env KANO_DOCKER_IMAGE \
+        --env KANO_DOCKER_CONTAINER \
+        --interactive \
+        --log-driver none \
+        --name "$KANO_DOCKER_CONTAINER" \
+        --rm \
+        --tty \
+        --volume "$PWD:$PWD" \
+        --workdir "$PWD" \
+        "$@" \
+        "$KANO_DOCKER_IMAGE" \
+        /bin/sh -c "\
+sudo useradd --uid $(id -u) --gid sudo --home-dir $HOME $(id -un); \
+sudo passwd --delete $(id -un) > /dev/null; \
+echo \"Press ENTER to exit\"; \
+read -r _;"
+    }
+
+    rm() {
+      if ! _does_container_exist; then
+        fail "Development container does not exist"
+      fi
+
+      if _is_container_running; then
+        fail "Development container is running. Run 'kano docker container stop'"
+      fi
+
+      _docker container rm "$@" "$KANO_DOCKER_CONTAINER"
+    }
+
+    start() {
+      if ! _does_container_exist; then
+        fail "Development container does not exist. Run 'kano docker container create'"
+      fi
+
+      if _is_container_running; then
+        fail "Development container is already running"
+      fi
+
+      _docker container start "$@" "$KANO_DOCKER_CONTAINER"
+    }
+
+    stop() {
+      if ! _does_container_exist; then
+        fail "Development container does not exist"
+      fi
+
+      if ! _is_container_running; then
+        fail "Development container is not running"
+      fi
+
+      _docker container stop "$@" "$KANO_DOCKER_CONTAINER"
+    }
+
+    exec_() {
+      if ! _does_container_exist; then
+        fail "Development container does not exist. Run 'kano docker container create'"
+      fi
+
+      if ! _is_container_running; then
+        fail "Development container is not running. Run 'kano docker container start'"
+      fi
+
+      _docker container exec \
+        --interactive \
+        --tty \
+        --user "$(id -un)" \
+        --workdir "$PWD" \
+        "$KANO_DOCKER_CONTAINER" \
+        "$@"
+    }
+
+    if [ "$1" = "exec" ]; then
+      shift
+      exec_ "$@"
     else
-      _docker_build "$@"
+      "$@"
     fi
   }
 
-  delete() {
-    if _does_development_image_exist; then
-      _docker image rm "$KANO_DEVELOPMENT_IMAGE"
-    fi
+  build() {
+    image build "$@"
   }
 
-  run() {
-    if ! _does_development_image_exist; then
-      fail "Development image does not exist. Run 'kano docker build'"
-    fi
+  rmi() {
+    image rm "$@"
+  }
 
-    # shellcheck disable=SC2046
-    _docker_run $(_insert_image_between_docker_run_options_and_command "$@" | xargs)
+  create() {
+    container create "$@"
+  }
+
+  rm() {
+    container rm "$@"
   }
 
   start() {
-    if ! _does_development_image_exist; then
-      fail "Development image does not exist. Run 'kano docker build'"
-    fi
-
-    _docker_run \
-      --detach \
-      --interactive \
-      --name "$KANO_DEVELOPMENT_CONTAINER" \
-      --tty \
-      "$@" "$KANO_DEVELOPMENT_IMAGE"
+    container start "$@"
   }
 
   stop() {
-    if ! _does_development_container_exist; then
-      fail "Development container does not exist. Run 'kano docker start'"
+    container stop "$@"
+  }
+
+  exec_() {
+    container exec_ "$@"
+  }
+
+  execute() {
+    if ! _does_image_exist; then
+      kano docker image build
     fi
 
-    _docker stop "$KANO_DEVELOPMENT_CONTAINER"
-  }
-
-  attach() {
-    if ! _does_development_container_exist; then
-      fail "Development container does not exist. Run 'kano docker start'"
+    if ! _does_container_exist; then
+      kano docker container create
     fi
 
-    _docker attach "$@" "$KANO_DEVELOPMENT_CONTAINER"
+    if ! _is_container_running; then
+      kano docker container start
+    fi
+
+    kano docker container exec_ "$@"
   }
 
-  enter() {
-    sh -c "kano docker start && kano docker attach"
+  shell() {
+    execute "$SHELL" --login
   }
 
-  "$@"
-}
+  clean() {
+    if _is_container_running; then
+      kano docker container stop
+    fi
 
-_docker_build() {
-  _docker build \
-    --file "$KANO_PROJECT_DIRECTORY/Dockerfile" \
-    --tag "$KANO_DEVELOPMENT_IMAGE" \
-    "$@" .
-}
+    if _does_container_exist; then
+      kano docker container rm
+    fi
 
-_docker_run() {
-  _docker run \
-    --env KANO_IS_IN_DOCKER=true \
-    --env KANO_DEVELOPMENT_IMAGE \
-    --env KANO_DEVELOPMENT_CONTAINER \
-    --log-driver none \
-    --rm \
-    --volume "$PWD:$PWD" \
-    --workdir "$PWD" \
+    if _does_image_exist; then
+      kano docker image rm
+    fi
+  }
+
+  if [ "$1" = "exec" ]; then
+    shift
+    exec_ "$@"
+  else
     "$@"
-}
-
-_insert_image_between_docker_run_options_and_command() {
-  HAS_INSERTED_IMAGE=false
-  IS_EXPECTING_VALUE=false
-  for ARGUMENT in "$@"; do
-    if $HAS_INSERTED_IMAGE; then
-      echo "$ARGUMENT"
-
-    elif _is_docker_run_flag "$ARGUMENT"; then
-      echo "$ARGUMENT"
-
-    elif _is_option_or_flag "$ARGUMENT"; then
-      echo "$ARGUMENT"
-      IS_EXPECTING_VALUE=true
-
-    elif $IS_EXPECTING_VALUE; then
-      echo "$ARGUMENT"
-      IS_EXPECTING_VALUE=false
-
-    else
-      echo "$KANO_DEVELOPMENT_IMAGE"
-      echo "$ARGUMENT"
-      HAS_INSERTED_IMAGE=true
-    fi
-  done
-}
-
-_is_docker_run_flag() {
-  case "$1" in
-    --detach | \
-      -d* | \
-      --disable-content-trust | \
-      --help | \
-      --init | \
-      --interactive | \
-      -i* | \
-      --no-healthcheck | \
-      --privileged | \
-      --read-only | \
-      --rm | \
-      --sig-proxy | \
-      --tty | \
-      -t*)
-      true
-      ;;
-
-    *)
-      false
-      ;;
-  esac
-}
-
-_is_option_or_flag() {
-  case "$1" in
-    -*)
-      true
-      ;;
-
-    *)
-      false
-      ;;
-  esac
+  fi
 }
 
 _is_docker_installed() {
@@ -185,12 +226,16 @@ _ensure_docker_daemon_is_running() {
   _docker version > /dev/null
 }
 
-_does_development_image_exist() {
-  [ -n "$(_docker image ls --quiet --filter reference="$KANO_DEVELOPMENT_IMAGE")" ]
+_does_image_exist() {
+  [ -n "$(_docker image ls --quiet --filter reference="$KANO_DOCKER_IMAGE")" ]
 }
 
-_does_development_container_exist() {
-  [ -n "$(_docker container ls --quiet --filter name="$KANO_DEVELOPMENT_CONTAINER")" ]
+_does_container_exist() {
+  [ -n "$(_docker container ls --all --quiet --filter name="$KANO_DOCKER_CONTAINER")" ]
+}
+
+_is_container_running() {
+  [ -n "$(_docker container ls --quiet --filter name="$KANO_DOCKER_CONTAINER")" ]
 }
 
 _docker() {

--- a/sources/builtin/tasks/dockered
+++ b/sources/builtin/tasks/dockered
@@ -1,9 +1,13 @@
 #!/bin/sh
 
 dockered_help() {
-    echo "Run a kano task in a docker container"
+  echo "Run a kano task in a docker container"
 }
 
 dockered() {
-  kano docker execute kano "$@"
+  _kano docker execute kano "$@"
+}
+
+_kano() {
+  command kano "$@"
 }

--- a/sources/builtin/tasks/dockered
+++ b/sources/builtin/tasks/dockered
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 dockered_help() {
-  echo "Run a task inside an ephemeral development container"
+    echo "Run a kano task in a docker container"
 }
 
 dockered() {
-  exec kano docker run kano "$@"
+  kano docker execute kano "$@"
 }

--- a/sources/scopes
+++ b/sources/scopes
@@ -42,7 +42,7 @@ scopes() {
   from_flag() {
     FLAG="$1"
 
-     case "$FLAG" in
+    case "$FLAG" in
       -u | --user)
         echo "$USER_SCOPE"
         ;;

--- a/templates/vscode/tasks/configure_vscode
+++ b/templates/vscode/tasks/configure_vscode
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# VS Code users should copy this task in their `.kano_user/tasks` directory if they intend to
+# attach VS Code to a kano docker development container
+
+# shellcheck disable=SC1090,SC1091
+. "$KANO_HELPERS/fail"
+. "$KANO_HELPERS/report"
+
+configure_vscode_help() {
+  echo "Configure VS Code for $KANO_PROJECT_NAME's development container"
+}
+
+configure_vscode() {
+  report info "Configuring VS Code for $KANO_PROJECT_NAME's development container"
+
+  OS_TYPE="$(uname)"
+  case "$OS_TYPE" in
+    Darwin)
+      CONFIGURATION_ROOT="$HOME/Library/Application Support"
+      ;;
+
+    Linux)
+      CONFIGURATION_ROOT="$HOME/.config"
+      ;;
+
+    *)
+      fail "Unhandled OS: $OS_TYPE"
+      ;;
+  esac
+
+  CONFIGURATION_DIRECTORY="$CONFIGURATION_ROOT/Code/User/globalStorage/ms-vscode-remote.remote-containers/nameConfigs"
+  CONTAINER_NAME="$(kano docker execute env | grep KANO_DOCKER_CONTAINER | cut -d "=" -f 2)"
+  CONFIGURATION="{ \"remoteUser\": \"$(id -un)\", \"workspaceFolder\": \"$PWD\" }"
+  mkdir -p "$CONFIGURATION_DIRECTORY"
+  echo "$CONFIGURATION" > "$CONFIGURATION_DIRECTORY/$CONTAINER_NAME.json"
+  report success "Successfully configured VS Code"
+}

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -273,7 +273,7 @@ Describe "docker"
 
         Context "when container does not exist"
           START_COMMAND="/bin/sh -c \
-sudo useradd --uid $(id -u) --gid sudo --no-create-home --home-dir $HOME --shell $SHELL $(id -un); \
+sudo useradd --uid $(id -u) --gid sudo --no-create-home --home-dir $HOME $(id -un); \
 sudo passwd --delete $(id -un) > /dev/null; \
 sudo chown -R $(id -un) $HOME; \
 sh -c 'kill -STOP \$\$'"

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -869,6 +869,67 @@ Describe "docker"
       End
     End
 
+    Describe "kill"
+      Context "when container does not exist"
+        It "should fail with the expected error message"
+          When run docker container 'kill'
+          The status should be failure
+          The variable fail_called_with should equal "Development container does not exist"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is not running"
+          It "should fail with the expected error message"
+            When run docker container 'kill'
+            The status should be failure
+            The variable fail_called_with should equal "Development container is not running"
+          End
+        End
+
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should kill container"
+            When run docker container 'kill'
+            The status should be success
+            The variable docker_called_with should equal "container kill $DEFAULT_CONTAINER"
+          End
+
+          Context "when passing extra docker flags and options"
+            It "should kill container with extra docker options and flags"
+              When run docker container 'kill' \
+                --some-docker-option some_value \
+                --some-docker-flag
+              The status should be success
+              The variable docker_called_with should start_with "container kill"
+              The variable docker_called_with should include "--some-docker-option some_value"
+              The variable docker_called_with should include "--some-docker-flag"
+              The variable docker_called_with should end_with "$DEFAULT_CONTAINER"
+            End
+          End
+
+          Context "when using custom container name"
+            SOME_CUSTOM_CONTAINER_NAME="some-custom-container-name"
+            export KANO_DOCKER_CONTAINER="$SOME_CUSTOM_CONTAINER_NAME"
+            It "should kill container with custom name"
+              When run docker container 'kill'
+              The status should be success
+              The variable docker_called_with should end_with "$SOME_CUSTOM_CONTAINER_NAME"
+            End
+          End
+
+          Context "when using shortcut form"
+            It "should delegate to container subcommand"
+              When run docker 'kill'
+              The status should be success
+              The variable docker_called_with should start_with "container kill"
+            End
+          End
+        End
+      End
+    End
+
     Describe "exec"
       SOME_COMMAND="some_command"
       SOME_PARAMETER="some_parameter"
@@ -1072,13 +1133,13 @@ Describe "docker"
 
         Context "when container is running"
           IS_CONTAINER_RUNNING=true
-          It "should stop container, delete container and delete image"
+          It "should kill container, delete container and delete image"
             When run docker clean
             The status should be success
             # shellcheck disable=SC2116
             The variable kano_called_with should equal "$(
               echo \
-                "docker container stop" \
+                "docker container kill" \
                 "docker container rm" \
                 "docker image rm" \
             )"

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -579,7 +579,7 @@ Describe "docker"
               "sudo useradd" \
                 "--uid $(id -u) --gid sudo --no-create-home --home-dir $HOME $(id -un);" \
               "sudo passwd --delete $(id -un) > /dev/null;" \
-              "sudo chown -R $(id -un) $HOME;" \
+              "sudo chown -R $(id -un) $HOME || true;" \
               "sh -c 'kill -STOP \$\$'" \
           )"
 

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -6,15 +6,15 @@ DEVELOPMENT_IMAGE="$KANO_PROJECT_NAME-dev"
 DEVELOPMENT_CONTAINER="$KANO_PROJECT_NAME-dev-container"
 
 Describe "docker"
-  sh() {
-    shift
-    # shellcheck disable=SC2068
-    $@
-  }
-
   kano() {
     # shellcheck disable=SC2034
-    kano_called_with="$*"
+    if [ -z "$kano_called_with" ]; then
+      kano_called_with="$*"
+
+    else
+      kano_called_with="$kano_called_with $*"
+    fi
+
     %preserve kano_called_with
   }
 
@@ -51,12 +51,16 @@ Describe "docker"
     "$IS_DOCKER_DAEMON_RUNNING" || exit 1
   }
 
-  _does_development_image_exist() {
-    "$DOES_DEVELOPMENT_IMAGE_EXIST"
+  _does_image_exist() {
+    "$DOES_IMAGE_EXIST"
   }
 
-  _does_development_container_exist() {
-    "$DOES_DEVELOPMENT_CONTAINER_EXIST"
+  _does_container_exist() {
+    "$DOES_CONTAINER_EXIST"
+  }
+
+  _is_container_running() {
+    "$IS_CONTAINER_RUNNING"
   }
 
   _docker() {
@@ -69,22 +73,23 @@ Describe "docker"
   IS_DOCKER_DAEMON_RUNNING=true
   DOES_PROJECT_DIRECTORY_EXIST=true
   DOES_DOCKERFILE_EXIST=true
-  DOES_DEVELOPMENT_IMAGE_EXIST=false
-  DOES_DEVELOPMENT_CONTAINER_EXIST=false
+  DOES_IMAGE_EXIST=false
+  DOES_CONTAINER_EXIST=false
+  IS_CONTAINER_RUNNING=false
 
   before_all() {
-    export INITIAL_KANO_DEVELOPMENT_IMAGE="$KANO_DEVELOPMENT_IMAGE"
-    export INITIAL_KANO_DEVELOPMENT_CONTAINER="$KANO_DEVELOPMENT_CONTAINER"
-    export INITIAL_KANO_IS_IN_DOCKER="$KANO_IS_IN_DOCKER"
-    export KANO_DEVELOPMENT_IMAGE=""
-    export KANO_DEVELOPMENT_CONTAINER=""
-    export KANO_IS_IN_DOCKER=false
+    export INITIAL_KANO_DOCKER_IMAGE="$KANO_DOCKER_IMAGE"
+    export INITIAL_KANO_DOCKER_CONTAINER="$KANO_DOCKER_CONTAINER"
+    export INITIAL_KANO_DOCKER="$KANO_DOCKER"
+    export KANO_DOCKER_IMAGE=""
+    export KANO_DOCKER_CONTAINER=""
+    export KANO_DOCKER=false
   }
 
   after_all() {
-    export KANO_DEVELOPMENT_IMAGE="$INITIAL_KANO_DEVELOPMENT_IMAGE"
-    export KANO_DEVELOPMENT_CONTAINER="$INITIAL_KANO_DEVELOPMENT_CONTAINER"
-    export KANO_IS_IN_DOCKER="$INITIAL_KANO_IS_IN_DOCKER"
+    export KANO_DOCKER_IMAGE="$INITIAL_KANO_DOCKER_IMAGE"
+    export KANO_DOCKER_CONTAINER="$INITIAL_KANO_DOCKER_CONTAINER"
+    export KANO_DOCKER="$INITIAL_KANO_DOCKER"
   }
 
   BeforeAll "before_all"
@@ -93,29 +98,11 @@ Describe "docker"
   It "has a help message"
     When run docker_help
     The status should be success
-    The output should equal "Work in an isolated development docker container"
+    The output should equal "Develop in a docker container"
   End
 
-  Context "when project kano directory does not exist"
-    DOES_PROJECT_DIRECTORY_EXIST=false
-    It "should fail with the expected error message"
-      When run docker
-      The status should be failure
-      The variable fail_called_with should equal "No kano directory exists in project"
-    End
-  End
-
-  Context "when no Dockerfile in project kano directory"
-    DOES_DOCKERFILE_EXIST=false
-    It "should fail with the expected error message"
-      When run docker
-      The status should be failure
-      The variable fail_called_with should equal "No Dockerfile in project kano directory"
-    End
-  End
-
-  Context "when inside a development container"
-    KANO_IS_IN_DOCKER=true
+  Context "when inside a container"
+    KANO_DOCKER=true
     It "should fail with the expected error message"
       When run docker
       The status should be failure
@@ -141,306 +128,549 @@ Describe "docker"
     End
   End
 
-  Describe "build"
-    It "should build the development image"
-      When run docker build
-      The status should be success
-      The variable docker_called_with should start_with "build"
-      The variable docker_called_with should include \
-        "--file $KANO_PROJECT_DIRECTORY/Dockerfile"
-      The variable docker_called_with should include "--tag $DEVELOPMENT_IMAGE"
-      The variable docker_called_with should end_with "."
-    End
-
-    Context "when using a custom image name"
-      SOME_CUSTOM_NAME="some-custom-name"
-      before_each() {
-        export KANO_DEVELOPMENT_IMAGE="$SOME_CUSTOM_NAME"
-      }
-
-      after_each() {
-        export KANO_DEVELOPMENT_IMAGE=""
-      }
-
-      BeforeEach "before_each"
-      AfterEach "after_each"
-      It "should build it with custom name"
-        When run docker build
-        The status should be success
-        The variable docker_called_with should include "--tag $SOME_CUSTOM_NAME"
+  Describe "image"
+    Describe "build"
+      Context "when project kano directory does not exist"
+        DOES_PROJECT_DIRECTORY_EXIST=false
+        It "should fail with the expected error message"
+          When run docker image build
+          The status should be failure
+          The variable fail_called_with should equal "No kano directory exists in project"
+        End
       End
-    End
 
-    Context "when development image already exist"
-      DOES_DEVELOPMENT_IMAGE_EXIST=true
-      It "should build it from cache"
-        When run docker build
-        The status should be success
-        The variable docker_called_with should include "--cache-from $DEVELOPMENT_IMAGE"
+      Context "when no Dockerfile in project kano directory"
+        DOES_DOCKERFILE_EXIST=false
+        It "should fail with the expected error message"
+          When run docker image build
+          The status should be failure
+          The variable fail_called_with should equal "No Dockerfile in project kano directory"
+        End
       End
-    End
 
-    Context "when passing extra docker build arguments"
-      It "should build the development image with extra arguments"
-        When run docker build --build-arg some_argument=some_argument
+      It "should build the image"
+        When run docker image build
         The status should be success
-        The variable docker_called_with should start_with "build"
+        The variable docker_called_with should start_with "image build"
         The variable docker_called_with should include \
           "--file $KANO_PROJECT_DIRECTORY/Dockerfile"
         The variable docker_called_with should include "--tag $DEVELOPMENT_IMAGE"
-        The variable docker_called_with should include \
-          "--build-arg some_argument=some_argument"
         The variable docker_called_with should end_with "."
       End
-    End
-  End
 
-  Describe "delete"
-    Context "when development image does not exist"
-      It "should not invoke docker"
-        When run docker delete
-        The status should be success
-        The variable docker_called_with should be undefined
-      End
-    End
-
-    Context "when development image exists"
-      DOES_DEVELOPMENT_IMAGE_EXIST=true
-      It "should delete it"
-        When run docker delete
-        The status should be success
-        The variable docker_called_with should include "image rm $DEVELOPMENT_IMAGE"
-      End
-    End
-  End
-
-  Describe "run"
-    Context "when development image does not exist"
-      It "should fail with the expected error message"
-        When run docker run some_command
-        The status should be failure
-        The variable fail_called_with should equal \
-          "Development image does not exist. Run 'kano docker build'"
-      End
-    End
-
-    Context "when development image exists"
-      DOES_DEVELOPMENT_IMAGE_EXIST=true
-      It "should run command in container"
-        When run docker run some_command
-        The status should be success
-        The variable docker_called_with should start_with "run"
-        The variable docker_called_with should include "--log-driver none"
-        The variable docker_called_with should include "--rm"
-        The variable docker_called_with should include "--volume $PWD:$PWD"
-        The variable docker_called_with should include "--workdir $PWD"
-        The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE some_command"
-      End
-
-      Context "when passing extra docker run options"
-        It "should run command in container with extra arguments"
-          When run docker run \
-            --some-docker-run-option some_value \
-            some_command --some-command-option
-          The status should be success
-          The variable docker_called_with should start_with "run"
-          The variable docker_called_with should include "--some-docker-run-option some_value"
-          The variable docker_called_with should end_with \
-            "$DEVELOPMENT_IMAGE some_command --some-command-option"
-        End
-      End
-
-      Context "when passing extra docker run flags"
-        It "should run command in container with extra flags"
-          When run docker run \
-            --disable-content-trust \
-            some_command --some-command-option
-          The status should be success
-          The variable docker_called_with should start_with "run"
-          The variable docker_called_with should include "--disable-content-trust"
-          The variable docker_called_with should end_with \
-            "$DEVELOPMENT_IMAGE some_command --some-command-option"
-        End
-      End
-
-      Context "when passing extra docker run flags and options"
-        It "should run command in container with extra flags"
-          When run docker run \
-            --disable-content-trust \
-            --some-docker-run-option some_value \
-            --some-docker-other-run-option some_value \
-            --detach \
-            some_command --some-command-option
-          The status should be success
-          The variable docker_called_with should start_with "run"
-          The variable docker_called_with should include "--disable-content-trust"
-          The variable docker_called_with should include "--some-docker-run-option some_value"
-          The variable docker_called_with should include \
-            "--some-docker-other-run-option some_value"
-          The variable docker_called_with should include "--detach"
-          The variable docker_called_with should end_with \
-            "$DEVELOPMENT_IMAGE some_command --some-command-option"
-        End
-      End
-    End
-  End
-
-  Describe "start"
-    Context "when development image does not exist"
-      It "should fail with the expected error message"
-        When run docker start
-        The status should be failure
-        The variable fail_called_with should equal \
-          "Development image does not exist. Run 'kano docker build'"
-      End
-    End
-
-    Context "when development image exists"
-      DOES_DEVELOPMENT_IMAGE_EXIST=true
-      It "should start container"
-        When run docker start
-        The status should be success
-        The variable docker_called_with should start_with "run"
-        The variable docker_called_with should include "--env KANO_IS_IN_DOCKER=true"
-        The variable docker_called_with should include "--env KANO_DEVELOPMENT_IMAGE"
-        The variable docker_called_with should include "--env KANO_DEVELOPMENT_CONTAINER"
-        The variable docker_called_with should include "--detach"
-        The variable docker_called_with should include "--interactive"
-        The variable docker_called_with should include "--log-driver none"
-        The variable docker_called_with should include "--name $DEVELOPMENT_CONTAINER"
-        The variable docker_called_with should include "--rm"
-        The variable docker_called_with should include "--tty"
-        The variable docker_called_with should include "--volume $PWD:$PWD"
-        The variable docker_called_with should include "--workdir $PWD"
-        The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE"
-      End
-
-      Context "when using a custom container name"
-        SOME_CUSTOM_NAME="some-custom-container-name"
+      Context "when using a custom image name"
+        SOME_CUSTOM_NAME="some-custom-name"
         before_each() {
-          export KANO_DEVELOPMENT_CONTAINER="$SOME_CUSTOM_NAME"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_NAME"
         }
 
         after_each() {
-          export KANO_DEVELOPMENT_CONTAINER=""
+          export KANO_DOCKER_IMAGE=""
         }
 
         BeforeEach "before_each"
         AfterEach "after_each"
-        It "should start it with custom name"
-          When run docker start
+        It "should build image with custom name"
+          When run docker image build
           The status should be success
-          The variable docker_called_with should include "--name $SOME_CUSTOM_NAME"
+          The variable docker_called_with should include "--tag $SOME_CUSTOM_NAME"
         End
       End
 
-      Context "when passing extra docker run options"
-        It "should run command in container with extra arguments"
-          When run docker start --some-docker-run-option some_value
+      Context "when image already exist"
+        DOES_IMAGE_EXIST=true
+        It "should build image from cache"
+          When run docker image build
           The status should be success
-          The variable docker_called_with should start_with "run"
-          The variable docker_called_with should include "--some-docker-run-option some_value"
-          The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE"
+          The variable docker_called_with should include "--cache-from $DEVELOPMENT_IMAGE"
         End
       End
 
-      Context "when passing extra docker run flags"
-        It "should run command in container with extra flags"
-          When run docker start --disable-content-trust
+      Context "when passing extra docker options and flags"
+        It "should build the image with extra docker options and flags"
+          When run docker image build \
+            --some-docker-option some_value \
+            --some-docker-flag
           The status should be success
-          The variable docker_called_with should start_with "run"
-          The variable docker_called_with should include "--disable-content-trust"
-          The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE"
+          The variable docker_called_with should start_with "image build"
+          The variable docker_called_with should include "--some-docker-option some_value"
+          The variable docker_called_with should include "--some-docker-flag"
+          The variable docker_called_with should end_with "."
         End
       End
 
-      Context "when passing extra docker run flags and options"
-        It "should run command in container with extra flags"
-          When run docker start \
-            --disable-content-trust \
-            --some-docker-run-option some_value \
-            --some-docker-other-run-option some_value \
+      Context "when using shortcut form"
+        It "should delegate to image subcommand"
+          When run docker build
           The status should be success
-          The variable docker_called_with should start_with "run"
-          The variable docker_called_with should include "--disable-content-trust"
-          The variable docker_called_with should include "--some-docker-run-option some_value"
-          The variable docker_called_with should include \
-            "--some-docker-other-run-option some_value"
-          The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE"
+          The variable docker_called_with should start_with "image build"
+        End
+      End
+    End
+
+    Describe "rm"
+      Context "when image does not exist"
+        It "should fail with the expected error message"
+          When run docker image rm
+          The status should be failure
+          The variable fail_called_with should equal "Development image does not exist"
+        End
+      End
+
+      Context "when image exists"
+        DOES_IMAGE_EXIST=true
+        It "should delete image"
+          When run docker image rm
+          The status should be success
+          The variable docker_called_with should include "image rm $DEVELOPMENT_IMAGE"
+        End
+
+        Context "when passing extra docker options and flags"
+          It "should delete the image with extra docker options and flags"
+            When run docker image rm \
+              --some-docker-option some_value \
+              --some-docker-flag
+            The status should be success
+            The variable docker_called_with should start_with "image rm"
+            The variable docker_called_with should include "--some-docker-option some_value"
+            The variable docker_called_with should include "--some-docker-flag"
+            The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE"
+          End
+        End
+
+        Context "when using shortcut form"
+          It "should delegate to image subcommand"
+            When run docker rmi
+            The status should be success
+            The variable docker_called_with should start_with "image rm"
+          End
         End
       End
     End
   End
 
-  Describe "stop"
-    Context "when development container does not exist"
-      It "should fail with the expected error message"
-        When run docker stop
-        The status should be failure
-        The variable fail_called_with should equal "Development container does not exist. Run 'kano docker start'"
+  Describe "container"
+    Describe "create"
+      Context "when image does not exist"
+        It "should fail with the expected error message"
+          When run docker container create
+          The status should be failure
+          The variable fail_called_with should equal \
+            "Development image does not exist. Run 'kano docker image build'"
+        End
+      End
+
+      Context "when image exists"
+        DOES_IMAGE_EXIST=true
+        Context "when container already exists"
+          DOES_CONTAINER_EXIST=true
+          It "should fail with the expected error message"
+            When run docker container create
+            The status should be failure
+            The variable fail_called_with should equal "Development container already exists"
+          End
+        End
+
+        Context "when container does not exist"
+          START_COMMAND="/bin/sh -c \
+sudo useradd --uid $(id -u) --gid sudo --home-dir $HOME $(id -un); \
+sudo passwd --delete $(id -un) > /dev/null; \
+echo \"Press ENTER to exit\"; \
+read -r _;"
+
+          It "should create container"
+            When run docker container create
+            The status should be success
+            The variable docker_called_with should start_with "container create"
+            The variable docker_called_with should include "--env KANO_DOCKER=true"
+            The variable docker_called_with should include "--env KANO_DOCKER_IMAGE"
+            The variable docker_called_with should include "--env KANO_DOCKER_CONTAINER"
+            The variable docker_called_with should include "--interactive"
+            The variable docker_called_with should include "--log-driver none"
+            The variable docker_called_with should include "--name $KANO_DOCKER_CONTAINER"
+            The variable docker_called_with should include "--rm"
+            The variable docker_called_with should include "--tty"
+            The variable docker_called_with should include "--volume $PWD:$PWD"
+            The variable docker_called_with should include "--workdir $PWD"
+            The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE $START_COMMAND"
+          End
+
+          Context "when passing extra docker flags and options"
+            It "should create container with extra docker options and flags"
+              When run docker container create \
+                --some-docker-option some_value \
+                --some-docker-flag
+              The status should be success
+              The variable docker_called_with should start_with "container create"
+              The variable docker_called_with should include "--some-docker-option some_value"
+              The variable docker_called_with should include "--some-docker-flag"
+              The variable docker_called_with should end_with \
+                "$DEVELOPMENT_IMAGE $START_COMMAND"
+            End
+          End
+
+          Context "when using shortcut form"
+            It "should delegate to container subcommand"
+              When run docker create
+              The status should be success
+              The variable docker_called_with should start_with "container create"
+            End
+          End
+        End
       End
     End
 
-    Context "when development container exists"
-      DOES_DEVELOPMENT_CONTAINER_EXIST=true
-      It "should stop container"
-        When run docker stop
+    Describe "rm"
+      Context "when container does not exist"
+        It "should fail with the expected error message"
+          When run docker container rm
+          The status should be failure
+          The variable fail_called_with should equal "Development container does not exist"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should fail with the expected error message"
+            When run docker container rm
+            The status should be failure
+            The variable fail_called_with should equal \
+              "Development container is running. Run 'kano docker container stop'"
+          End
+        End
+
+        Context "when container is not running"
+          It "should delete container"
+            When run docker container rm
+            The status should be success
+            The variable docker_called_with should include "container rm $DEVELOPMENT_CONTAINER"
+          End
+
+          Context "when passing extra docker flags and options"
+            It "should delete container with extra docker options and flags"
+              When run docker container rm \
+                --some-docker-option some_value \
+                --some-docker-flag
+              The status should be success
+              The variable docker_called_with should start_with "container rm"
+              The variable docker_called_with should include "--some-docker-option some_value"
+              The variable docker_called_with should include "--some-docker-flag"
+              The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+            End
+          End
+
+
+          Context "when using shortcut form"
+            It "should delegate to container subcommand"
+              When run docker rm
+              The status should be success
+              The variable docker_called_with should start_with "container rm"
+            End
+          End
+        End
+      End
+    End
+
+    Describe "start"
+      Context "when container does not exist"
+        It "should fail with the expected error message"
+          When run docker container start
+          The status should be failure
+          The variable fail_called_with should equal \
+            "Development container does not exist. Run 'kano docker container create'"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should fail with the expected error message"
+            When run docker container start
+            The status should be failure
+            The variable fail_called_with should equal \
+              "Development container is already running"
+          End
+        End
+
+        Context "when container is not running"
+          It "should start container"
+            When run docker container start
+            The status should be success
+            The variable docker_called_with should equal \
+              "container start $DEVELOPMENT_CONTAINER"
+          End
+
+          Context "when passing extra docker flags and options"
+            It "should start container with extra docker options and flags"
+              When run docker container start \
+                --some-docker-option some_value \
+                --some-docker-flag
+              The status should be success
+              The variable docker_called_with should start_with "container start"
+              The variable docker_called_with should include "--some-docker-option some_value"
+              The variable docker_called_with should include "--some-docker-flag"
+              The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+            End
+          End
+
+          Context "when using shortcut form"
+            It "should delegate to container subcommand"
+              When run docker start
+              The status should be success
+              The variable docker_called_with should start_with "container start"
+            End
+          End
+        End
+      End
+    End
+
+    Describe "stop"
+      Context "when container does not exist"
+        It "should fail with the expected error message"
+          When run docker container stop
+          The status should be failure
+          The variable fail_called_with should equal "Development container does not exist"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is not running"
+          It "should fail with the expected error message"
+            When run docker container stop
+            The status should be failure
+            The variable fail_called_with should equal "Development container is not running"
+          End
+        End
+
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should stop container"
+            When run docker container stop
+            The status should be success
+            The variable docker_called_with should equal \
+              "container stop $DEVELOPMENT_CONTAINER"
+          End
+
+          Context "when passing extra docker flags and options"
+            It "should stop container with extra docker options and flags"
+              When run docker container stop \
+                --some-docker-option some_value \
+                --some-docker-flag
+              The status should be success
+              The variable docker_called_with should start_with "container stop"
+              The variable docker_called_with should include "--some-docker-option some_value"
+              The variable docker_called_with should include "--some-docker-flag"
+              The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+            End
+          End
+
+          Context "when using shortcut form"
+            It "should delegate to container subcommand"
+              When run docker stop
+              The status should be success
+              The variable docker_called_with should start_with "container stop"
+            End
+          End
+        End
+      End
+    End
+
+    Describe "exec"
+      SOME_COMMAND="some_command"
+      Context "when container does not exist"
+        It "should fail with the expected error message"
+          When run docker container 'exec' "$SOME_COMMAND"
+          The status should be failure
+          The variable fail_called_with should equal \
+            "Development container does not exist. Run 'kano docker container create'"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is not running"
+          It "should fail with the expected error message"
+            When run docker container 'exec' "$SOME_COMMAND"
+            The status should be failure
+            The variable fail_called_with should equal \
+              "Development container is not running. Run 'kano docker container start'"
+          End
+        End
+
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should exec command"
+            When run docker container 'exec' "$SOME_COMMAND"
+            The status should be success
+            The variable docker_called_with should start_with "container exec"
+            The variable docker_called_with should include "--interactive"
+            The variable docker_called_with should include "--tty"
+            The variable docker_called_with should include "--user $(id -un)"
+            The variable docker_called_with should include "--workdir $PWD"
+            The variable docker_called_with should end_with \
+              "$DEVELOPMENT_CONTAINER $SOME_COMMAND"
+          End
+
+          Context "when using shortcut form"
+            It "should delegate to container subcommand"
+              When run docker 'exec'
+              The status should be success
+              The variable docker_called_with should start_with "container exec"
+            End
+          End
+        End
+      End
+    End
+  End
+
+  Describe "execute"
+    Context "when image does not exist"
+      It "should build image, create container, start container and exec command"
+        When run docker execute "$SOME_COMMAND"
         The status should be success
-        The variable docker_called_with should equal "stop $DEVELOPMENT_CONTAINER"
+        The variable kano_called_with should equal "\
+docker image build \
+docker container create \
+docker container start \
+docker container exec_ $SOME_COMMAND"
+      End
+    End
+
+    Context "when image exists"
+      DOES_IMAGE_EXIST=true
+      Context "when container does not exist"
+        It "should create container, start container and exec command"
+          When run docker execute "$SOME_COMMAND"
+          The status should be success
+          The variable kano_called_with should equal "\
+docker container create \
+docker container start \
+docker container exec_ $SOME_COMMAND"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is not running"
+          It "should start container and exec command"
+            When run docker execute "$SOME_COMMAND"
+            The status should be success
+            The variable kano_called_with should equal "\
+docker container start \
+docker container exec_ $SOME_COMMAND"
+          End
+        End
+
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should exec command"
+            When run docker execute "$SOME_COMMAND"
+            The status should be success
+            The variable kano_called_with should equal "\
+docker container exec_ $SOME_COMMAND"
+          End
+        End
       End
     End
   End
 
-  Describe "attach"
-    Context "when development container does not exist"
-      It "should fail with the expected error message"
-        When run docker attach
-        The status should be failure
-        The variable fail_called_with should equal "Development container does not exist. Run 'kano docker start'"
-      End
-    End
-
-    Context "when development container exists"
-      DOES_DEVELOPMENT_CONTAINER_EXIST=true
-      It "should attach to container"
-        When run docker attach
+  Describe "shell"
+    Context "when image does not exist"
+      It "should build image, create container, start container and exec same shell as host's"
+        When run docker shell
         The status should be success
-        The variable docker_called_with should equal "attach $DEVELOPMENT_CONTAINER"
+        The variable kano_called_with should equal "\
+docker image build \
+docker container create \
+docker container start \
+docker container exec_ $SHELL --login"
       End
+    End
 
-      Context "when passing extra docker attach flags"
-        It "should attach to container with extra flags"
-          When run docker attach --no-stdin
+    Context "when image exists"
+      DOES_IMAGE_EXIST=true
+      Context "when container does not exist"
+        It "should create container, start container and exec same shell as host's"
+          When run docker shell
           The status should be success
-          The variable docker_called_with should start_with "attach"
-          The variable docker_called_with should include "--no-stdin"
-          The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+          The variable kano_called_with should equal "\
+docker container create \
+docker container start \
+docker container exec_ $SHELL --login"
         End
       End
 
-      Context "when passing extra docker attach options"
-        It "should attach to container with extra options"
-          When run docker attach --detach-keys ctrl-y
-          The status should be success
-          The variable docker_called_with should start_with "attach"
-          The variable docker_called_with should include "--detach-keys ctrl-y"
-          The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is not running"
+          It "should start container and exec same shell as host's"
+            When run docker shell
+            The status should be success
+            The variable kano_called_with should equal "\
+docker container start \
+docker container exec_ $SHELL --login"
+          End
+        End
+
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should exec same shell as host's"
+            When run docker shell
+            The status should be success
+            The variable kano_called_with should equal "docker container exec_ $SHELL --login"
+          End
         End
       End
     End
   End
 
-  Describe "enter"
-    It "should invoke docker start task"
-      When run docker enter
-      The status should be success
-      The variable kano_called_with should start_with "docker start"
+  Describe "clean"
+    Context "when image does not exist"
+      It "should do nothing"
+        When run docker clean
+        The status should be success
+        The variable kano_called_with should be undefined
+      End
     End
 
-    It "should invoke docker start task"
-      When run docker enter
-      The status should be success
-      The variable kano_called_with should end_with "docker attach"
+    Context "when image exists"
+      DOES_IMAGE_EXIST=true
+      Context "when container does not exist"
+        It "should delete image"
+          When run docker clean
+          The status should be success
+          The variable kano_called_with should equal "docker image rm"
+        End
+      End
+
+      Context "when container exists"
+        DOES_CONTAINER_EXIST=true
+        Context "when container is not running"
+          It "should delete container and delete image"
+            When run docker clean
+            The status should be success
+            The variable kano_called_with should equal "\
+docker container rm \
+docker image rm"
+          End
+        End
+
+        Context "when container is running"
+          IS_CONTAINER_RUNNING=true
+          It "should stop container, delete container and delete image"
+            When run docker clean
+            The status should be success
+            The variable kano_called_with should equal "\
+docker container stop \
+docker container rm \
+docker image rm"
+          End
+        End
+      End
     End
   End
 End

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -579,7 +579,7 @@ Describe "docker"
               "sudo useradd" \
                 "--uid $(id -u) --gid sudo --no-create-home --home-dir $HOME $(id -un);" \
               "sudo passwd --delete $(id -un) > /dev/null;" \
-              "sudo chown -R $(id -un) $HOME || true;" \
+              "sudo chown -R $(id -un) $HOME;" \
               "sh -c 'kill -STOP \$\$'" \
           )"
 

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -946,20 +946,17 @@ Describe "docker"
     End
   End
 
-  Describe "execute"
-    SOME_COMMAND="some_command"
-    SOME_PARAMETER="some_parameter"
+  Describe "boot"
     Context "when image does not exist"
-      It "should build image, create container, start container and exec command"
-        When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
+      It "should build image, create container and start container"
+        When run docker boot
         The status should be success
         # shellcheck disable=SC2116
         The variable kano_called_with should equal "$(
           echo \
             "docker image build" \
             "docker container create" \
-            "docker container start" \
-            "docker container exec_ $SOME_COMMAND" "$SOME_PARAMETER" \
+            "docker container start"
         )"
       End
     End
@@ -967,15 +964,14 @@ Describe "docker"
     Context "when image exists"
       DOES_IMAGE_EXIST=true
       Context "when container does not exist"
-        It "should create container, start container and exec command"
-          When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
+        It "should create container and start container"
+          When run docker boot
           The status should be success
           # shellcheck disable=SC2116
           The variable kano_called_with should equal "$(
             echo \
               "docker container create" \
-              "docker container start" \
-              "docker container exec_ $SOME_COMMAND $SOME_PARAMETER" \
+              "docker container start"
           )"
         End
       End
@@ -983,152 +979,59 @@ Describe "docker"
       Context "when container exists"
         DOES_CONTAINER_EXIST=true
         Context "when container is not running"
-          It "should start container and exec command"
-            When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
+          It "should start container"
+            When run docker boot
             The status should be success
-            # shellcheck disable=SC2116
-            The variable kano_called_with should equal "$(
-              echo \
-                "docker container start" \
-                "docker container exec_ $SOME_COMMAND $SOME_PARAMETER" \
-            )"
+            The variable kano_called_with should equal "docker container start"
           End
         End
 
         Context "when container is running"
           IS_CONTAINER_RUNNING=true
-          It "should exec command"
-            When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
+          It "should do nothing"
+            When run docker boot
             The status should be success
-            The variable kano_called_with should equal \
-              "docker container exec_ $SOME_COMMAND $SOME_PARAMETER"
+            The variable kano_called_with should be undefined
           End
         End
       End
     End
   End
 
+  Describe "execute"
+    SOME_COMMAND="some_command"
+    SOME_PARAMETER="some_parameter"
+    It "should boot and exec command"
+      When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
+      The status should be success
+      # shellcheck disable=SC2116
+      The variable kano_called_with should equal "$(
+        echo \
+          "docker boot" \
+          "docker container exec_ $SOME_COMMAND" "$SOME_PARAMETER" \
+      )"
+    End
+  End
+
   Describe "shell"
     Context "when SHELL environment variable is not defined"
       export SHELL=
-      Context "when image does not exist"
-        It "should build image, create container, start container and exec sh"
-          When run docker shell
-          The status should be success
-          # shellcheck disable=SC2116
-          The variable kano_called_with should equal "$(
-            echo \
-              "docker image build" \
-              "docker container create" \
-              "docker container start" \
-              "docker container exec_ --interactive --tty /bin/sh --login" \
-          )"
-        End
-      End
-
-      Context "when image exists"
-        DOES_IMAGE_EXIST=true
-        Context "when container does not exist"
-          It "should create container, start container and exec sh"
-            When run docker shell
-            The status should be success
-            # shellcheck disable=SC2116
-            The variable kano_called_with should equal "$(
-              echo \
-                "docker container create" \
-                "docker container start" \
-                "docker container exec_ --interactive --tty /bin/sh --login" \
-            )"
-          End
-        End
-
-        Context "when container exists"
-          DOES_CONTAINER_EXIST=true
-          Context "when container is not running"
-            It "should start container and exec sh"
-              When run docker shell
-              The status should be success
-              # shellcheck disable=SC2116
-              The variable kano_called_with should equal "$(
-                echo \
-                  "docker container start" \
-                  "docker container exec_ --interactive --tty /bin/sh --login" \
-              )"
-            End
-          End
-
-          Context "when container is running"
-            IS_CONTAINER_RUNNING=true
-            It "should exec same shell as host's"
-              When run docker shell
-              The status should be success
-              The variable kano_called_with should equal \
-                "docker container exec_ --interactive --tty /bin/sh --login"
-            End
-          End
-        End
+      It "exececute sh"
+        When run docker shell
+        The status should be success
+        The variable kano_called_with should equal \
+          "docker execute --interactive --tty /bin/sh --login"
       End
     End
 
     Context "when SHELL environment variable is defined"
       SOME_SHELL="some_shell"
       export SHELL="$SOME_SHELL"
-      Context "when image does not exist"
-        It "should build image, create container, start container and exec same shell as host's"
-          When run docker shell
-          The status should be success
-          # shellcheck disable=SC2116
-          The variable kano_called_with should equal "$(
-            echo \
-              "docker image build" \
-              "docker container create" \
-              "docker container start" \
-              "docker container exec_ --interactive --tty $SOME_SHELL --login" \
-          )"
-        End
-      End
-
-      Context "when image exists"
-        DOES_IMAGE_EXIST=true
-        Context "when container does not exist"
-          It "should create container, start container and exec same shell as host's"
-            When run docker shell
-            The status should be success
-            # shellcheck disable=SC2116
-            The variable kano_called_with should equal "$(
-              echo \
-                "docker container create" \
-                "docker container start" \
-                "docker container exec_ --interactive --tty $SOME_SHELL --login" \
-            )"
-          End
-        End
-
-        Context "when container exists"
-          DOES_CONTAINER_EXIST=true
-          Context "when container is not running"
-            It "should start container and exec same shell as host's"
-              When run docker shell
-              The status should be success
-              # shellcheck disable=SC2116
-              The variable kano_called_with should equal "$(
-                echo \
-                  "docker container start" \
-                  "docker container exec_ --interactive --tty $SOME_SHELL --login" \
-              )"
-            End
-          End
-
-          Context "when container is running"
-            IS_CONTAINER_RUNNING=true
-            It "should exec same shell as host's"
-              When run docker shell
-              The status should be success
-              The variable kano_called_with should equal \
-                "docker container exec_ --interactive --tty $SOME_SHELL --login"
-            End
-          End
-        End
+      It "exececute same shell as host's"
+        When run docker shell
+        The status should be success
+        The variable kano_called_with should equal \
+          "docker execute --interactive --tty $SOME_SHELL --login"
       End
     End
   End

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -1010,6 +1010,7 @@ Describe "docker"
 
   Describe "shell"
     Context "when SHELL environment variable is not defined"
+      export SHELL=
       Context "when image does not exist"
         It "should build image, create container, start container and exec sh"
           When run docker shell

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -45,7 +45,7 @@ Describe "docker"
 
   _docker() {
     # shellcheck disable=SC2034
-    if [ -z "$kano_called_with" ]; then
+    if [ -z "$docker_called_with" ]; then
       docker_called_with="$*"
 
     else
@@ -141,7 +141,6 @@ Describe "docker"
         It "should fail with the expected error message"
           When run docker image build
           The status should be failure
-          # shellcheck disable=SC2116
           The variable fail_called_with should equal "$(
             echo \
               "Cannot rebuild a versioned image. Run 'kano docker pull $KANO_DOCKER_TAG' or" \
@@ -155,7 +154,6 @@ Describe "docker"
         It "should fail with the expected error message"
           When run docker image build
           The status should be failure
-          # shellcheck disable=SC2116
           The variable fail_called_with should equal "$(
             echo \
               "No Dockerfile at '$DEFAULT_FILE'. Create one or set 'KANO_DOCKER_FILE'" \
@@ -572,7 +570,6 @@ Describe "docker"
         End
 
         Context "when container does not exist"
-          # shellcheck disable=SC2116
           START_COMMAND="$(
             echo \
               "/bin/sh -c" \
@@ -832,7 +829,11 @@ Describe "docker"
           It "should stop container"
             When run docker container stop
             The status should be success
-            The variable docker_called_with should equal "container stop $DEFAULT_CONTAINER"
+            The variable docker_called_with should equal "$(
+              echo \
+                "container stop $DEFAULT_CONTAINER" \
+                "container wait $DEFAULT_CONTAINER"
+            )"
           End
 
           Context "when passing extra docker flags and options"
@@ -841,10 +842,14 @@ Describe "docker"
                 --some-docker-option some_value \
                 --some-docker-flag
               The status should be success
-              The variable docker_called_with should start_with "container stop"
-              The variable docker_called_with should include "--some-docker-option some_value"
-              The variable docker_called_with should include "--some-docker-flag"
-              The variable docker_called_with should end_with "$DEFAULT_CONTAINER"
+              The variable docker_called_with should equal "$(
+                echo \
+                  "container stop" \
+                    "--some-docker-option some_value" \
+                    "--some-docker-flag" \
+                    "$DEFAULT_CONTAINER" \
+                  "container wait $DEFAULT_CONTAINER"
+              )"
             End
           End
 
@@ -854,7 +859,11 @@ Describe "docker"
             It "should stop container with custom name"
               When run docker container stop
               The status should be success
-              The variable docker_called_with should end_with "$SOME_CUSTOM_CONTAINER_NAME"
+              The variable docker_called_with should equal "$(
+                echo \
+                  "container stop $SOME_CUSTOM_CONTAINER_NAME" \
+                  "container wait $SOME_CUSTOM_CONTAINER_NAME"
+              )"
             End
           End
 
@@ -893,7 +902,11 @@ Describe "docker"
           It "should kill container"
             When run docker container 'kill'
             The status should be success
-            The variable docker_called_with should equal "container kill $DEFAULT_CONTAINER"
+            The variable docker_called_with should equal "$(
+              echo \
+                "container kill $DEFAULT_CONTAINER" \
+                "container wait $DEFAULT_CONTAINER"
+            )"
           End
 
           Context "when passing extra docker flags and options"
@@ -902,10 +915,14 @@ Describe "docker"
                 --some-docker-option some_value \
                 --some-docker-flag
               The status should be success
-              The variable docker_called_with should start_with "container kill"
-              The variable docker_called_with should include "--some-docker-option some_value"
-              The variable docker_called_with should include "--some-docker-flag"
-              The variable docker_called_with should end_with "$DEFAULT_CONTAINER"
+              The variable docker_called_with should equal "$(
+                echo \
+                  "container kill" \
+                    "--some-docker-option some_value" \
+                    "--some-docker-flag" \
+                    "$DEFAULT_CONTAINER" \
+                  "container wait $DEFAULT_CONTAINER"
+              )"
             End
           End
 
@@ -915,7 +932,11 @@ Describe "docker"
             It "should kill container with custom name"
               When run docker container 'kill'
               The status should be success
-              The variable docker_called_with should end_with "$SOME_CUSTOM_CONTAINER_NAME"
+              The variable docker_called_with should equal "$(
+                echo \
+                  "container kill $SOME_CUSTOM_CONTAINER_NAME" \
+                  "container wait $SOME_CUSTOM_CONTAINER_NAME"
+              )"
             End
           End
 
@@ -1009,16 +1030,31 @@ Describe "docker"
 
   Describe "boot"
     Context "when image does not exist"
-      It "should build image, create container and start container"
-        When run docker boot
-        The status should be success
-        # shellcheck disable=SC2116
-        The variable kano_called_with should equal "$(
-          echo \
-            "docker image build" \
-            "docker container create" \
-            "docker container start"
-        )"
+      Context "when KANO_DOCKER_TAG is latest"
+        It "should build image, create container and start container"
+          When run docker boot
+          The status should be success
+          The variable kano_called_with should equal "$(
+            echo \
+              "docker image build" \
+              "docker container create" \
+              "docker container start"
+          )"
+        End
+      End
+
+      Context "when KANO_DOCKER_TAG is not latest"
+        export KANO_DOCKER_TAG="some-tag"
+        It "should pull image, create container and start container"
+          When run docker boot
+          The status should be success
+          The variable kano_called_with should equal "$(
+            echo \
+              "docker image pull" \
+              "docker container create" \
+              "docker container start"
+          )"
+        End
       End
     End
 
@@ -1028,7 +1064,6 @@ Describe "docker"
         It "should create container and start container"
           When run docker boot
           The status should be success
-          # shellcheck disable=SC2116
           The variable kano_called_with should equal "$(
             echo \
               "docker container create" \
@@ -1065,7 +1100,6 @@ Describe "docker"
     It "should boot and exec command"
       When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
       The status should be success
-      # shellcheck disable=SC2116
       The variable kano_called_with should equal "$(
         echo \
           "docker boot" \
@@ -1122,7 +1156,6 @@ Describe "docker"
           It "should delete container and delete image"
             When run docker clean
             The status should be success
-            # shellcheck disable=SC2116
             The variable kano_called_with should equal "$(
               echo \
                 "docker container rm" \
@@ -1136,7 +1169,6 @@ Describe "docker"
           It "should kill container, delete container and delete image"
             When run docker clean
             The status should be success
-            # shellcheck disable=SC2116
             The variable kano_called_with should equal "$(
               echo \
                 "docker container kill" \

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -273,10 +273,10 @@ Describe "docker"
 
         Context "when container does not exist"
           START_COMMAND="/bin/sh -c \
-sudo useradd --uid $(id -u) --gid sudo --home-dir $HOME $(id -un); \
+sudo useradd --uid $(id -u) --gid sudo --no-create-home --home-dir $HOME --shell $SHELL $(id -un); \
 sudo passwd --delete $(id -un) > /dev/null; \
-echo \"Press ENTER to exit\"; \
-read -r _;"
+sudo chown -R $(id -un) $HOME; \
+sh -c 'kill -STOP \$\$'"
 
           It "should create container"
             When run docker container create
@@ -285,11 +285,9 @@ read -r _;"
             The variable docker_called_with should include "--env KANO_DOCKER=true"
             The variable docker_called_with should include "--env KANO_DOCKER_IMAGE"
             The variable docker_called_with should include "--env KANO_DOCKER_CONTAINER"
-            The variable docker_called_with should include "--interactive"
             The variable docker_called_with should include "--log-driver none"
             The variable docker_called_with should include "--name $KANO_DOCKER_CONTAINER"
             The variable docker_called_with should include "--rm"
-            The variable docker_called_with should include "--tty"
             The variable docker_called_with should include "--volume $PWD:$PWD"
             The variable docker_called_with should include "--workdir $PWD"
             The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE $START_COMMAND"
@@ -507,8 +505,6 @@ read -r _;"
             When run docker container 'exec' "$SOME_COMMAND"
             The status should be success
             The variable docker_called_with should start_with "container exec"
-            The variable docker_called_with should include "--interactive"
-            The variable docker_called_with should include "--tty"
             The variable docker_called_with should include "--user $(id -un)"
             The variable docker_called_with should include "--workdir $PWD"
             The variable docker_called_with should end_with \
@@ -587,7 +583,7 @@ docker container exec_ $SOME_COMMAND"
 docker image build \
 docker container create \
 docker container start \
-docker container exec_ $SHELL --login"
+docker container exec_ --interactive --tty $SHELL --login"
       End
     End
 
@@ -600,7 +596,7 @@ docker container exec_ $SHELL --login"
           The variable kano_called_with should equal "\
 docker container create \
 docker container start \
-docker container exec_ $SHELL --login"
+docker container exec_ --interactive --tty $SHELL --login"
         End
       End
 
@@ -612,7 +608,7 @@ docker container exec_ $SHELL --login"
             The status should be success
             The variable kano_called_with should equal "\
 docker container start \
-docker container exec_ $SHELL --login"
+docker container exec_ --interactive --tty $SHELL --login"
           End
         End
 
@@ -621,7 +617,8 @@ docker container exec_ $SHELL --login"
           It "should exec same shell as host's"
             When run docker shell
             The status should be success
-            The variable kano_called_with should equal "docker container exec_ $SHELL --login"
+            The variable kano_called_with should equal "\
+docker container exec_ --interactive --tty $SHELL --login"
           End
         End
       End

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -6,18 +6,6 @@ DEVELOPMENT_IMAGE="$KANO_PROJECT_NAME-dev"
 DEVELOPMENT_CONTAINER="$KANO_PROJECT_NAME-dev-container"
 
 Describe "docker"
-  kano() {
-    # shellcheck disable=SC2034
-    if [ -z "$kano_called_with" ]; then
-      kano_called_with="$*"
-
-    else
-      kano_called_with="$kano_called_with $*"
-    fi
-
-    %preserve kano_called_with
-  }
-
   fail() {
     # shellcheck disable=SC2034
     fail_called_with="$*"
@@ -65,8 +53,26 @@ Describe "docker"
 
   _docker() {
     # shellcheck disable=SC2034
-    docker_called_with="$*"
+    if [ -z "$kano_called_with" ]; then
+      docker_called_with="$*"
+
+    else
+      docker_called_with="$docker_called_with $*"
+    fi
+
     %preserve docker_called_with
+  }
+
+  _kano() {
+    # shellcheck disable=SC2034
+    if [ -z "$kano_called_with" ]; then
+      kano_called_with="$*"
+
+    else
+      kano_called_with="$kano_called_with $*"
+    fi
+
+    %preserve kano_called_with
   }
 
   IS_DOCKER_INSTALLED=true

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -2,10 +2,11 @@
 
 Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/docker"
 
-DEVELOPMENT_IMAGE="$KANO_PROJECT_NAME-dev"
-DEVELOPMENT_CONTAINER="$KANO_PROJECT_NAME-dev-container"
-
 Describe "docker"
+  DEFAULT_FILE="$KANO_PROJECT_DIRECTORY/Dockerfile"
+  DEFAULT_IMAGE="$KANO_PROJECT_NAME-dev"
+  DEFAULT_CONTAINER="$KANO_PROJECT_NAME-dev-container"
+
   fail() {
     # shellcheck disable=SC2034
     fail_called_with="$*"
@@ -13,17 +14,8 @@ Describe "docker"
     exit 1
   }
 
-  does_directory_exist() {
-    if [ "$1" = "$KANO_PROJECT_DIRECTORY" ]; then
-      "$DOES_PROJECT_DIRECTORY_EXIST"
-
-    else
-      false
-    fi
-  }
-
   does_file_exist() {
-    if [ "$1" = "$KANO_PROJECT_DIRECTORY/Dockerfile" ]; then
+    if [ "$1" = "$KANO_DOCKER_FILE" ]; then
       "$DOES_DOCKERFILE_EXIST"
 
     else
@@ -77,23 +69,31 @@ Describe "docker"
 
   IS_DOCKER_INSTALLED=true
   IS_DOCKER_DAEMON_RUNNING=true
-  DOES_PROJECT_DIRECTORY_EXIST=true
   DOES_DOCKERFILE_EXIST=true
   DOES_IMAGE_EXIST=false
   DOES_CONTAINER_EXIST=false
   IS_CONTAINER_RUNNING=false
 
   before_all() {
+    export INITIAL_KANO_DOCKER_FILE="$KANO_DOCKER_FILE"
+    export INITIAL_KANO_DOCKER_REGISTRY="$KANO_DOCKER_REGISTRY"
     export INITIAL_KANO_DOCKER_IMAGE="$KANO_DOCKER_IMAGE"
+    export INITIAL_KANO_DOCKER_TAG="$KANO_DOCKER_TAG"
     export INITIAL_KANO_DOCKER_CONTAINER="$KANO_DOCKER_CONTAINER"
     export INITIAL_KANO_DOCKER="$KANO_DOCKER"
-    export KANO_DOCKER_IMAGE=""
-    export KANO_DOCKER_CONTAINER=""
-    export KANO_DOCKER=false
+    export KANO_DOCKER_FILE=
+    export KANO_DOCKER_REGISTRY=
+    export KANO_DOCKER_IMAGE=
+    export KANO_DOCKER_TAG=
+    export KANO_DOCKER_CONTAINER=
+    export KANO_DOCKER=
   }
 
   after_all() {
+    export KANO_DOCKER_FILE="$INITIAL_KANO_DOCKER_FILE"
+    export KANO_DOCKER_REGISTRY="$INITIAL_KANO_DOCKER_REGISTRY"
     export KANO_DOCKER_IMAGE="$INITIAL_KANO_DOCKER_IMAGE"
+    export KANO_DOCKER_TAG="$INITIAL_KANO_DOCKER_TAG"
     export KANO_DOCKER_CONTAINER="$INITIAL_KANO_DOCKER_CONTAINER"
     export KANO_DOCKER="$INITIAL_KANO_DOCKER"
   }
@@ -136,59 +136,59 @@ Describe "docker"
 
   Describe "image"
     Describe "build"
-      Context "when project kano directory does not exist"
-        DOES_PROJECT_DIRECTORY_EXIST=false
+      Context "when configured tag is not 'latest'"
+        export KANO_DOCKER_TAG="some-tag"
         It "should fail with the expected error message"
           When run docker image build
           The status should be failure
-          The variable fail_called_with should equal "No kano directory exists in project"
+          # shellcheck disable=SC2116
+          The variable fail_called_with should equal "$(
+            echo \
+              "Cannot rebuild a versioned image. Run 'kano docker pull $KANO_DOCKER_TAG' or" \
+              "unset 'KANO_DOCKER_TAG' environment variable" \
+          )"
         End
       End
 
-      Context "when no Dockerfile in project kano directory"
+      Context "when Dockerfile not found"
         DOES_DOCKERFILE_EXIST=false
         It "should fail with the expected error message"
           When run docker image build
           The status should be failure
-          The variable fail_called_with should equal "No Dockerfile in project kano directory"
+          # shellcheck disable=SC2116
+          The variable fail_called_with should equal "$(
+            echo \
+              "No Dockerfile at '$DEFAULT_FILE'. Create one or set 'KANO_DOCKER_FILE'" \
+              "environment variable to configure a different location" \
+          )"
         End
       End
 
-      It "should build the image"
-        When run docker image build
-        The status should be success
-        The variable docker_called_with should start_with "image build"
-        The variable docker_called_with should include \
-          "--file $KANO_PROJECT_DIRECTORY/Dockerfile"
-        The variable docker_called_with should include "--tag $DEVELOPMENT_IMAGE"
-        The variable docker_called_with should end_with "."
-      End
-
-      Context "when using a custom image name"
-        SOME_CUSTOM_NAME="some-custom-name"
-        before_each() {
-          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_NAME"
-        }
-
-        after_each() {
-          export KANO_DOCKER_IMAGE=""
-        }
-
-        BeforeEach "before_each"
-        AfterEach "after_each"
-        It "should build image with custom name"
+      Context "when no registry configured"
+        It "should build the image"
           When run docker image build
           The status should be success
-          The variable docker_called_with should include "--tag $SOME_CUSTOM_NAME"
+          The variable docker_called_with should start_with "image build"
+          The variable docker_called_with should include "--file $DEFAULT_FILE"
+          The variable docker_called_with should include "--tag $DEFAULT_IMAGE:latest"
+          The variable docker_called_with should end_with "."
         End
       End
 
-      Context "when image already exist"
-        DOES_IMAGE_EXIST=true
-        It "should build image from cache"
+      Context "when a registry is configured"
+        export KANO_DOCKER_REGISTRY="some-registry.com"
+        It "should build the image from cache"
           When run docker image build
           The status should be success
-          The variable docker_called_with should include "--cache-from $DEVELOPMENT_IMAGE"
+          The variable docker_called_with should start_with "image build"
+          The variable docker_called_with should include "--build-arg BUILDKIT_INLINE_CACHE=1"
+          The variable docker_called_with should include \
+            "--cache-from $KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:latest"
+          The variable docker_called_with should include "--file $DEFAULT_FILE"
+          The variable docker_called_with should include "--pull"
+          The variable docker_called_with should include \
+            "--tag $KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:latest"
+          The variable docker_called_with should end_with "."
         End
       End
 
@@ -202,6 +202,39 @@ Describe "docker"
           The variable docker_called_with should include "--some-docker-option some_value"
           The variable docker_called_with should include "--some-docker-flag"
           The variable docker_called_with should end_with "."
+        End
+      End
+
+      Context "when using custom docker file"
+        SOME_CUSTOM_DOCKERFILE="/some_directory/Dockerfile"
+        export KANO_DOCKER_FILE="$SOME_CUSTOM_DOCKERFILE"
+        It "should build the image from custom file"
+          When run docker image build
+          The status should be success
+          The variable docker_called_with should include "--file $SOME_CUSTOM_DOCKERFILE"
+        End
+      End
+
+      Context "when using custom image name"
+        SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+        export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+        It "should build the image with custom name"
+          When run docker image build
+          The status should be success
+          The variable docker_called_with should include "--tag $SOME_CUSTOM_IMAGE_NAME:latest"
+        End
+      End
+
+      Context "when registry is configured and using custom image name"
+        SOME_REGISTRY="some-registry"
+        export KANO_DOCKER_REGISTRY="$SOME_REGISTRY"
+        SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+        export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+        It "should build the image with custom name and registry"
+          When run docker image build
+          The status should be success
+          The variable docker_called_with should include \
+            "--tag $SOME_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:latest"
         End
       End
 
@@ -228,7 +261,7 @@ Describe "docker"
         It "should delete image"
           When run docker image rm
           The status should be success
-          The variable docker_called_with should include "image rm $DEVELOPMENT_IMAGE"
+          The variable docker_called_with should equal "image rm $DEFAULT_IMAGE:latest"
         End
 
         Context "when passing extra docker options and flags"
@@ -240,7 +273,53 @@ Describe "docker"
             The variable docker_called_with should start_with "image rm"
             The variable docker_called_with should include "--some-docker-option some_value"
             The variable docker_called_with should include "--some-docker-flag"
-            The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE"
+            The variable docker_called_with should end_with "$DEFAULT_IMAGE:latest"
+          End
+        End
+
+        Context "when registry is configured"
+          SOME_REGISTRY="some-registry"
+          export KANO_DOCKER_REGISTRY="$SOME_REGISTRY"
+          It "should delete the image with registry prefix"
+            When run docker image rm
+            The status should be success
+            The variable docker_called_with should end_with \
+              "$SOME_REGISTRY/$DEFAULT_IMAGE:latest"
+          End
+        End
+
+        Context "when using custom image name"
+          SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+          It "should delete the image with custom name"
+            When run docker image rm
+            The status should be success
+            The variable docker_called_with should end_with "$SOME_CUSTOM_IMAGE_NAME:latest"
+          End
+        End
+
+        Context "when using specific tag"
+          SOME_TAG="some-tag"
+          export KANO_DOCKER_TAG="$SOME_TAG"
+          It "should delete the image with specific tag"
+            When run docker image rm
+            The status should be success
+            The variable docker_called_with should end_with "$DEFAULT_IMAGE:$SOME_TAG"
+          End
+        End
+
+        Context "when registry is configred, using custom image name and a specific tag"
+          SOME_REGISTRY="some-registry"
+          export KANO_DOCKER_REGISTRY="$SOME_REGISTRY"
+          SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+          SOME_TAG="some-tag"
+          export KANO_DOCKER_TAG="$SOME_TAG"
+          It "should delete the image with registry prefix, custom name and specific tag"
+            When run docker image rm
+            The status should be success
+            The variable docker_called_with should end_with \
+              "$SOME_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:$SOME_TAG"
           End
         End
 
@@ -249,6 +328,221 @@ Describe "docker"
             When run docker rmi
             The status should be success
             The variable docker_called_with should start_with "image rm"
+          End
+        End
+      End
+    End
+
+    Describe "pull"
+      Context "when no registry configured"
+        It "should fail with the expected error message"
+          When run docker image pull
+          The status should be failure
+          The variable fail_called_with should equal \
+            "No container registry configured. Set 'KANO_DOCKER_REGISTRY' environment variable"
+        End
+      End
+
+      Context "when a registry is configured"
+        export KANO_DOCKER_REGISTRY="some-registry.com"
+        It "should pull the image"
+          When run docker image pull
+          The status should be success
+          The variable docker_called_with should equal \
+            "image pull $KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:latest"
+        End
+
+        Context "when specifying a tag"
+          SOME_TAG="some-tag"
+          It "should pull the image with specified tag"
+            When run docker image pull "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should equal \
+              "image pull $KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:$SOME_TAG"
+          End
+        End
+
+        Context "when passing extra docker options and flags"
+          SOME_PULL_FLAG="--quiet"
+          SOME_PULL_OPTION_KEY="--platform"
+          SOME_PULL_OPTION_VALUE="amd64"
+          It "should pull the image with extra docker options and flags"
+            When run docker image pull \
+              "$SOME_PULL_FLAG" \
+              "$SOME_PULL_OPTION_KEY" "$SOME_PULL_OPTION_VALUE"
+            The status should be success
+            The variable docker_called_with should start_with "image pull"
+            The variable docker_called_with should include "$SOME_PULL_FLAG"
+            The variable docker_called_with should include \
+              "$SOME_PULL_OPTION_KEY $SOME_PULL_OPTION_VALUE"
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:latest"
+          End
+        End
+
+        Context "when passing extra docker options and flags and specifying a tag"
+          SOME_TAG="some-tag"
+          SOME_PULL_FLAG="--quiet"
+          SOME_PULL_OPTION_KEY="--platform"
+          SOME_PULL_OPTION_VALUE="amd64"
+          It "should pull the image with extra docker options and flags"
+            When run docker image pull \
+              "$SOME_PULL_FLAG" \
+              "$SOME_PULL_OPTION_KEY" "$SOME_PULL_OPTION_VALUE" \
+              "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should start_with "image pull"
+            The variable docker_called_with should include "$SOME_PULL_FLAG"
+            The variable docker_called_with should include \
+              "$SOME_PULL_OPTION_KEY $SOME_PULL_OPTION_VALUE"
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:$SOME_TAG"
+          End
+        End
+
+        Context "when using custom image name"
+          SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+          It "should pull the image with custom name"
+            When run docker image pull
+            The status should be success
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:latest"
+          End
+        End
+
+        Context "when using custom image name and specific tag"
+          SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+          SOME_TAG="some-tag"
+          It "should pull the image with custom name and specific tag"
+            When run docker image pull "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:$SOME_TAG"
+          End
+        End
+
+        Context "when using shortcut form"
+          It "should delegate to image subcommand"
+            When run docker pull
+            The status should be success
+            The variable docker_called_with should start_with "image pull"
+          End
+        End
+      End
+    End
+
+    Describe "push"
+      Context "when no registry configured"
+        It "should fail with the expected error message"
+          When run docker image push
+          The status should be failure
+          The variable fail_called_with should equal \
+            "No container registry configured. Set 'KANO_DOCKER_REGISTRY' environment variable"
+        End
+      End
+
+      Context "when a registry is configured"
+        export KANO_DOCKER_REGISTRY="some-registry.com"
+        It "should push the image"
+          When run docker image push
+          The status should be success
+          The variable docker_called_with should equal \
+            "image push $KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:latest"
+        End
+
+        Context "when specifying a tag"
+          SOME_TAG="some-tag"
+          It "should push the image with specified tag"
+            When run docker image push "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should equal \
+              "image push $KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:$SOME_TAG"
+          End
+        End
+
+        Context "when passing extra docker flags"
+          SOME_PUSH_FLAG="--quiet"
+          It "should push the image with extra docker flags"
+            When run docker image push "$SOME_PUSH_FLAG"
+            The status should be success
+            The variable docker_called_with should start_with "image push"
+            The variable docker_called_with should include "$SOME_PUSH_FLAG"
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:latest"
+          End
+        End
+
+        Context "when passing extra docker flags and specifying a tag"
+          SOME_TAG="some-tag"
+          SOME_PUSH_FLAG="--quiet"
+          It "should push the image with extra docker options and flags"
+            When run docker image push "$SOME_PUSH_FLAG" "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should start_with "image push"
+            The variable docker_called_with should include "$SOME_PUSH_FLAG"
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$DEFAULT_IMAGE:$SOME_TAG"
+          End
+        End
+
+        Context "when using custom image name"
+          SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+          It "should push the image with custom name"
+            When run docker image push
+            The status should be success
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:latest"
+          End
+        End
+
+        Context "when using custom image name and specific tag"
+          SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+          export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+          SOME_TAG="some-tag"
+          It "should push the image with custom name and specific tag"
+            When run docker image push "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should end_with \
+              "$KANO_DOCKER_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:$SOME_TAG"
+          End
+        End
+
+        Context "when using shortcut form"
+          It "should delegate to image subcommand"
+            When run docker push
+            The status should be success
+            The variable docker_called_with should start_with "image push"
+          End
+        End
+      End
+    End
+
+    Describe "tag"
+      Context "when no tag provided"
+        It "should fail with the expected error message"
+          When run docker image tag
+          The status should be failure
+          The variable fail_called_with should equal "No tag provided"
+        End
+      End
+
+      Context "when a tag is provided"
+        SOME_TAG="some-tag"
+        It "should tag the image"
+          When run docker image tag "$SOME_TAG"
+          The status should be success
+          The variable docker_called_with should equal \
+            "image tag $DEFAULT_IMAGE:latest $DEFAULT_IMAGE:$SOME_TAG"
+        End
+
+        Context "when using shortcut form"
+          It "should delegate to image subcommand"
+            When run docker tag "$SOME_TAG"
+            The status should be success
+            The variable docker_called_with should start_with "image tag"
           End
         End
       End
@@ -278,11 +572,16 @@ Describe "docker"
         End
 
         Context "when container does not exist"
-          START_COMMAND="/bin/sh -c \
-sudo useradd --uid $(id -u) --gid sudo --no-create-home --home-dir $HOME $(id -un); \
-sudo passwd --delete $(id -un) > /dev/null; \
-sudo chown -R $(id -un) $HOME; \
-sh -c 'kill -STOP \$\$'"
+          # shellcheck disable=SC2116
+          START_COMMAND="$(
+            echo \
+              "/bin/sh -c" \
+              "sudo useradd" \
+                "--uid $(id -u) --gid sudo --no-create-home --home-dir $HOME $(id -un);" \
+              "sudo passwd --delete $(id -un) > /dev/null;" \
+              "sudo chown -R $(id -un) $HOME;" \
+              "sh -c 'kill -STOP \$\$'" \
+          )"
 
           It "should create container"
             When run docker container create
@@ -292,11 +591,12 @@ sh -c 'kill -STOP \$\$'"
             The variable docker_called_with should include "--env KANO_DOCKER_IMAGE"
             The variable docker_called_with should include "--env KANO_DOCKER_CONTAINER"
             The variable docker_called_with should include "--log-driver none"
-            The variable docker_called_with should include "--name $KANO_DOCKER_CONTAINER"
+            The variable docker_called_with should include "--name $DEFAULT_CONTAINER"
             The variable docker_called_with should include "--rm"
             The variable docker_called_with should include "--volume $PWD:$PWD"
             The variable docker_called_with should include "--workdir $PWD"
-            The variable docker_called_with should end_with "$DEVELOPMENT_IMAGE $START_COMMAND"
+            The variable docker_called_with should end_with \
+              "$DEFAULT_IMAGE:latest $START_COMMAND"
           End
 
           Context "when passing extra docker flags and options"
@@ -309,7 +609,66 @@ sh -c 'kill -STOP \$\$'"
               The variable docker_called_with should include "--some-docker-option some_value"
               The variable docker_called_with should include "--some-docker-flag"
               The variable docker_called_with should end_with \
-                "$DEVELOPMENT_IMAGE $START_COMMAND"
+                "$DEFAULT_IMAGE:latest $START_COMMAND"
+            End
+          End
+
+          Context "when registry is configured"
+            SOME_REGISTRY="some-registry"
+            export KANO_DOCKER_REGISTRY="$SOME_REGISTRY"
+            It "should create container from image with registry prefix"
+              When run docker container create
+              The status should be success
+              The variable docker_called_with should end_with \
+                "$SOME_REGISTRY/$DEFAULT_IMAGE:latest $START_COMMAND"
+            End
+          End
+
+          Context "when using custom image name"
+            SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+            export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+            It "should create container from image with custom name"
+              When run docker container create
+              The status should be success
+              The variable docker_called_with should end_with \
+                "$SOME_CUSTOM_IMAGE_NAME:latest $START_COMMAND"
+            End
+          End
+
+          Context "when specifying a tag"
+            SOME_TAG="some-tag"
+            export KANO_DOCKER_TAG="$SOME_TAG"
+            It "should create container from image with specific tag"
+              When run docker container create
+              The status should be success
+              The variable docker_called_with should end_with \
+                "$DEFAULT_IMAGE:$SOME_TAG $START_COMMAND"
+            End
+          End
+
+          Context "when registry is configured, using a custom image name and specifying a tag"
+            SOME_REGISTRY="some-registry"
+            export KANO_DOCKER_REGISTRY="$SOME_REGISTRY"
+            SOME_CUSTOM_IMAGE_NAME="some-custom-image-name"
+            export KANO_DOCKER_IMAGE="$SOME_CUSTOM_IMAGE_NAME"
+            SOME_TAG="some-tag"
+            export KANO_DOCKER_TAG="$SOME_TAG"
+            It "should create container from image with registry, custom name and tag"
+              When run docker container create
+              The status should be success
+              The variable docker_called_with should end_with \
+                "$SOME_REGISTRY/$SOME_CUSTOM_IMAGE_NAME:$SOME_TAG $START_COMMAND"
+            End
+          End
+
+          Context "when using custom container name"
+            SOME_CUSTOM_CONTAINER_NAME="some-custom-container-name"
+            export KANO_DOCKER_CONTAINER="$SOME_CUSTOM_CONTAINER_NAME"
+            It "should create container with custom name"
+              When run docker container create
+              The status should be success
+              The variable docker_called_with should include \
+                "--name $SOME_CUSTOM_CONTAINER_NAME"
             End
           End
 
@@ -349,7 +708,7 @@ sh -c 'kill -STOP \$\$'"
           It "should delete container"
             When run docker container rm
             The status should be success
-            The variable docker_called_with should include "container rm $DEVELOPMENT_CONTAINER"
+            The variable docker_called_with should include "container rm $DEFAULT_CONTAINER"
           End
 
           Context "when passing extra docker flags and options"
@@ -361,10 +720,19 @@ sh -c 'kill -STOP \$\$'"
               The variable docker_called_with should start_with "container rm"
               The variable docker_called_with should include "--some-docker-option some_value"
               The variable docker_called_with should include "--some-docker-flag"
-              The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+              The variable docker_called_with should end_with "$DEFAULT_CONTAINER"
             End
           End
 
+          Context "when using custom container name"
+            SOME_CUSTOM_CONTAINER_NAME="some-custom-container-name"
+            export KANO_DOCKER_CONTAINER="$SOME_CUSTOM_CONTAINER_NAME"
+            It "should delete container with custom name"
+              When run docker container rm
+              The status should be success
+              The variable docker_called_with should end_with "$SOME_CUSTOM_CONTAINER_NAME"
+            End
+          End
 
           Context "when using shortcut form"
             It "should delegate to container subcommand"
@@ -403,8 +771,7 @@ sh -c 'kill -STOP \$\$'"
           It "should start container"
             When run docker container start
             The status should be success
-            The variable docker_called_with should equal \
-              "container start $DEVELOPMENT_CONTAINER"
+            The variable docker_called_with should equal "container start $DEFAULT_CONTAINER"
           End
 
           Context "when passing extra docker flags and options"
@@ -416,7 +783,17 @@ sh -c 'kill -STOP \$\$'"
               The variable docker_called_with should start_with "container start"
               The variable docker_called_with should include "--some-docker-option some_value"
               The variable docker_called_with should include "--some-docker-flag"
-              The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+              The variable docker_called_with should end_with "$DEFAULT_CONTAINER"
+            End
+          End
+
+          Context "when using custom container name"
+            SOME_CUSTOM_CONTAINER_NAME="some-custom-container-name"
+            export KANO_DOCKER_CONTAINER="$SOME_CUSTOM_CONTAINER_NAME"
+            It "should start container with custom name"
+              When run docker container start
+              The status should be success
+              The variable docker_called_with should end_with "$SOME_CUSTOM_CONTAINER_NAME"
             End
           End
 
@@ -455,8 +832,7 @@ sh -c 'kill -STOP \$\$'"
           It "should stop container"
             When run docker container stop
             The status should be success
-            The variable docker_called_with should equal \
-              "container stop $DEVELOPMENT_CONTAINER"
+            The variable docker_called_with should equal "container stop $DEFAULT_CONTAINER"
           End
 
           Context "when passing extra docker flags and options"
@@ -468,7 +844,17 @@ sh -c 'kill -STOP \$\$'"
               The variable docker_called_with should start_with "container stop"
               The variable docker_called_with should include "--some-docker-option some_value"
               The variable docker_called_with should include "--some-docker-flag"
-              The variable docker_called_with should end_with "$DEVELOPMENT_CONTAINER"
+              The variable docker_called_with should end_with "$DEFAULT_CONTAINER"
+            End
+          End
+
+          Context "when using custom container name"
+            SOME_CUSTOM_CONTAINER_NAME="some-custom-container-name"
+            export KANO_DOCKER_CONTAINER="$SOME_CUSTOM_CONTAINER_NAME"
+            It "should stop container with custom name"
+              When run docker container stop
+              The status should be success
+              The variable docker_called_with should end_with "$SOME_CUSTOM_CONTAINER_NAME"
             End
           End
 
@@ -485,9 +871,10 @@ sh -c 'kill -STOP \$\$'"
 
     Describe "exec"
       SOME_COMMAND="some_command"
+      SOME_PARAMETER="some_parameter"
       Context "when container does not exist"
         It "should fail with the expected error message"
-          When run docker container 'exec' "$SOME_COMMAND"
+          When run docker container 'exec' "$SOME_COMMAND" "$SOME_PARAMETER"
           The status should be failure
           The variable fail_called_with should equal \
             "Development container does not exist. Run 'kano docker container create'"
@@ -498,7 +885,7 @@ sh -c 'kill -STOP \$\$'"
         DOES_CONTAINER_EXIST=true
         Context "when container is not running"
           It "should fail with the expected error message"
-            When run docker container 'exec' "$SOME_COMMAND"
+            When run docker container 'exec' "$SOME_COMMAND" "$SOME_PARAMETER"
             The status should be failure
             The variable fail_called_with should equal \
               "Development container is not running. Run 'kano docker container start'"
@@ -508,13 +895,43 @@ sh -c 'kill -STOP \$\$'"
         Context "when container is running"
           IS_CONTAINER_RUNNING=true
           It "should exec command"
-            When run docker container 'exec' "$SOME_COMMAND"
+            When run docker container 'exec' "$SOME_COMMAND" "$SOME_PARAMETER"
             The status should be success
             The variable docker_called_with should start_with "container exec"
             The variable docker_called_with should include "--user $(id -un)"
             The variable docker_called_with should include "--workdir $PWD"
             The variable docker_called_with should end_with \
-              "$DEVELOPMENT_CONTAINER $SOME_COMMAND"
+              "$DEFAULT_CONTAINER $SOME_COMMAND $SOME_PARAMETER"
+          End
+
+           Context "when passing extra docker flags and options"
+            SOME_EXEC_FLAG="--tty"
+            SOME_EXEC_OPTION_KEY="--env"
+            SOME_EXEC_OPTION_VALUE="SOME_ENV"
+            It "should exec command with extra docker options and flags"
+              When run docker container 'exec' \
+                "$SOME_EXEC_FLAG" \
+                "$SOME_EXEC_OPTION_KEY" "$SOME_EXEC_OPTION_VALUE" \
+                "$SOME_COMMAND" "$SOME_PARAMETER"
+              The status should be success
+              The variable docker_called_with should start_with "container exec"
+              The variable docker_called_with should include "$SOME_EXEC_FLAG"
+              The variable docker_called_with should include \
+                "$SOME_EXEC_OPTION_KEY $SOME_EXEC_OPTION_VALUE"
+              The variable docker_called_with should end_with \
+                "$DEFAULT_CONTAINER $SOME_COMMAND $SOME_PARAMETER"
+            End
+          End
+
+          Context "when using custom container name"
+            SOME_CUSTOM_CONTAINER_NAME="some-custom-container-name"
+            export KANO_DOCKER_CONTAINER="$SOME_CUSTOM_CONTAINER_NAME"
+            It "should exec command in container with custom name"
+              When run docker container 'exec' "$SOME_COMMAND" "$SOME_PARAMETER"
+              The status should be success
+              The variable docker_called_with should end_with \
+                "$SOME_CUSTOM_CONTAINER_NAME $SOME_COMMAND $SOME_PARAMETER"
+            End
           End
 
           Context "when using shortcut form"
@@ -530,15 +947,20 @@ sh -c 'kill -STOP \$\$'"
   End
 
   Describe "execute"
+    SOME_COMMAND="some_command"
+    SOME_PARAMETER="some_parameter"
     Context "when image does not exist"
       It "should build image, create container, start container and exec command"
-        When run docker execute "$SOME_COMMAND"
+        When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
         The status should be success
-        The variable kano_called_with should equal "\
-docker image build \
-docker container create \
-docker container start \
-docker container exec_ $SOME_COMMAND"
+        # shellcheck disable=SC2116
+        The variable kano_called_with should equal "$(
+          echo \
+            "docker image build" \
+            "docker container create" \
+            "docker container start" \
+            "docker container exec_ $SOME_COMMAND" "$SOME_PARAMETER" \
+        )"
       End
     End
 
@@ -546,12 +968,15 @@ docker container exec_ $SOME_COMMAND"
       DOES_IMAGE_EXIST=true
       Context "when container does not exist"
         It "should create container, start container and exec command"
-          When run docker execute "$SOME_COMMAND"
+          When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
           The status should be success
-          The variable kano_called_with should equal "\
-docker container create \
-docker container start \
-docker container exec_ $SOME_COMMAND"
+          # shellcheck disable=SC2116
+          The variable kano_called_with should equal "$(
+            echo \
+              "docker container create" \
+              "docker container start" \
+              "docker container exec_ $SOME_COMMAND $SOME_PARAMETER" \
+          )"
         End
       End
 
@@ -559,21 +984,24 @@ docker container exec_ $SOME_COMMAND"
         DOES_CONTAINER_EXIST=true
         Context "when container is not running"
           It "should start container and exec command"
-            When run docker execute "$SOME_COMMAND"
+            When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
             The status should be success
-            The variable kano_called_with should equal "\
-docker container start \
-docker container exec_ $SOME_COMMAND"
+            # shellcheck disable=SC2116
+            The variable kano_called_with should equal "$(
+              echo \
+                "docker container start" \
+                "docker container exec_ $SOME_COMMAND $SOME_PARAMETER" \
+            )"
           End
         End
 
         Context "when container is running"
           IS_CONTAINER_RUNNING=true
           It "should exec command"
-            When run docker execute "$SOME_COMMAND"
+            When run docker execute "$SOME_COMMAND" "$SOME_PARAMETER"
             The status should be success
-            The variable kano_called_with should equal "\
-docker container exec_ $SOME_COMMAND"
+            The variable kano_called_with should equal \
+              "docker container exec_ $SOME_COMMAND $SOME_PARAMETER"
           End
         End
       End
@@ -581,50 +1009,123 @@ docker container exec_ $SOME_COMMAND"
   End
 
   Describe "shell"
-    Context "when image does not exist"
-      It "should build image, create container, start container and exec same shell as host's"
-        When run docker shell
-        The status should be success
-        The variable kano_called_with should equal "\
-docker image build \
-docker container create \
-docker container start \
-docker container exec_ --interactive --tty $SHELL --login"
-      End
-    End
-
-    Context "when image exists"
-      DOES_IMAGE_EXIST=true
-      Context "when container does not exist"
-        It "should create container, start container and exec same shell as host's"
+    Context "when SHELL environment variable is not defined"
+      Context "when image does not exist"
+        It "should build image, create container, start container and exec sh"
           When run docker shell
           The status should be success
-          The variable kano_called_with should equal "\
-docker container create \
-docker container start \
-docker container exec_ --interactive --tty $SHELL --login"
+          # shellcheck disable=SC2116
+          The variable kano_called_with should equal "$(
+            echo \
+              "docker image build" \
+              "docker container create" \
+              "docker container start" \
+              "docker container exec_ --interactive --tty /bin/sh --login" \
+          )"
         End
       End
 
-      Context "when container exists"
-        DOES_CONTAINER_EXIST=true
-        Context "when container is not running"
-          It "should start container and exec same shell as host's"
+      Context "when image exists"
+        DOES_IMAGE_EXIST=true
+        Context "when container does not exist"
+          It "should create container, start container and exec sh"
             When run docker shell
             The status should be success
-            The variable kano_called_with should equal "\
-docker container start \
-docker container exec_ --interactive --tty $SHELL --login"
+            # shellcheck disable=SC2116
+            The variable kano_called_with should equal "$(
+              echo \
+                "docker container create" \
+                "docker container start" \
+                "docker container exec_ --interactive --tty /bin/sh --login" \
+            )"
           End
         End
 
-        Context "when container is running"
-          IS_CONTAINER_RUNNING=true
-          It "should exec same shell as host's"
+        Context "when container exists"
+          DOES_CONTAINER_EXIST=true
+          Context "when container is not running"
+            It "should start container and exec sh"
+              When run docker shell
+              The status should be success
+              # shellcheck disable=SC2116
+              The variable kano_called_with should equal "$(
+                echo \
+                  "docker container start" \
+                  "docker container exec_ --interactive --tty /bin/sh --login" \
+              )"
+            End
+          End
+
+          Context "when container is running"
+            IS_CONTAINER_RUNNING=true
+            It "should exec same shell as host's"
+              When run docker shell
+              The status should be success
+              The variable kano_called_with should equal \
+                "docker container exec_ --interactive --tty /bin/sh --login"
+            End
+          End
+        End
+      End
+    End
+
+    Context "when SHELL environment variable is defined"
+      SOME_SHELL="some_shell"
+      export SHELL="$SOME_SHELL"
+      Context "when image does not exist"
+        It "should build image, create container, start container and exec same shell as host's"
+          When run docker shell
+          The status should be success
+          # shellcheck disable=SC2116
+          The variable kano_called_with should equal "$(
+            echo \
+              "docker image build" \
+              "docker container create" \
+              "docker container start" \
+              "docker container exec_ --interactive --tty $SOME_SHELL --login" \
+          )"
+        End
+      End
+
+      Context "when image exists"
+        DOES_IMAGE_EXIST=true
+        Context "when container does not exist"
+          It "should create container, start container and exec same shell as host's"
             When run docker shell
             The status should be success
-            The variable kano_called_with should equal "\
-docker container exec_ --interactive --tty $SHELL --login"
+            # shellcheck disable=SC2116
+            The variable kano_called_with should equal "$(
+              echo \
+                "docker container create" \
+                "docker container start" \
+                "docker container exec_ --interactive --tty $SOME_SHELL --login" \
+            )"
+          End
+        End
+
+        Context "when container exists"
+          DOES_CONTAINER_EXIST=true
+          Context "when container is not running"
+            It "should start container and exec same shell as host's"
+              When run docker shell
+              The status should be success
+              # shellcheck disable=SC2116
+              The variable kano_called_with should equal "$(
+                echo \
+                  "docker container start" \
+                  "docker container exec_ --interactive --tty $SOME_SHELL --login" \
+              )"
+            End
+          End
+
+          Context "when container is running"
+            IS_CONTAINER_RUNNING=true
+            It "should exec same shell as host's"
+              When run docker shell
+              The status should be success
+              The variable kano_called_with should equal \
+                "docker container exec_ --interactive --tty $SOME_SHELL --login"
+            End
           End
         End
       End
@@ -656,9 +1157,12 @@ docker container exec_ --interactive --tty $SHELL --login"
           It "should delete container and delete image"
             When run docker clean
             The status should be success
-            The variable kano_called_with should equal "\
-docker container rm \
-docker image rm"
+            # shellcheck disable=SC2116
+            The variable kano_called_with should equal "$(
+              echo \
+                "docker container rm" \
+                "docker image rm" \
+            )"
           End
         End
 
@@ -667,10 +1171,13 @@ docker image rm"
           It "should stop container, delete container and delete image"
             When run docker clean
             The status should be success
-            The variable kano_called_with should equal "\
-docker container stop \
-docker container rm \
-docker image rm"
+            # shellcheck disable=SC2116
+            The variable kano_called_with should equal "$(
+              echo \
+                "docker container stop" \
+                "docker container rm" \
+                "docker image rm" \
+            )"
           End
         End
       End

--- a/tests/suites/unit/builtin/tasks/dockered.test
+++ b/tests/suites/unit/builtin/tasks/dockered.test
@@ -3,9 +3,15 @@
 Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/dockered"
 
 Describe "dockered"
-  kano() {
+  _kano() {
     # shellcheck disable=SC2034
-    kano_called_with="$*"
+    if [ -z "$kano_called_with" ]; then
+      kano_called_with="$*"
+
+    else
+      kano_called_with="$kano_called_with $*"
+    fi
+
     %preserve kano_called_with
   }
 

--- a/tests/suites/unit/builtin/tasks/dockered.test
+++ b/tests/suites/unit/builtin/tasks/dockered.test
@@ -3,10 +3,6 @@
 Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/dockered"
 
 Describe "dockered"
-  exec() {
-    "$@"
-  }
-
   kano() {
     # shellcheck disable=SC2034
     kano_called_with="$*"
@@ -16,12 +12,12 @@ Describe "dockered"
   It "has a help message"
     When run dockered_help
     The status should be success
-    The output should equal "Run a task inside an ephemeral development container"
+    The output should equal "Run a kano task in a docker container"
   End
 
   It "should delegate to docker task"
     When run dockered some_command
     The status should be success
-    The variable kano_called_with should equal "docker run kano some_command"
+    The variable kano_called_with should equal "docker execute kano some_command"
   End
 End


### PR DESCRIPTION
# Docker

Fixes #50 
Fixes #46 

## Mapping host user into container

- Enhances compatibility with mounted volumes
- Smoothes permission problems

## `create`, `start` and `exec` container instead of `start & attach` or `run`

- Closer to docker's metal
- No need to know exact docker cli flags anymore, just passing them all dynamically
- Allows mapping host user non-awkwardly
- Allows having multiple shell attached to same container
- Allows container reuse

## Long forms

- Added subcommand support (`docker image build = docker build, etc.`) for image and container

## Shortcuts

- Removed enter 
- Added `execute`, which builds the image, create and start the container and execs a command in it
- Added `shell`, which executes the host user's shell inside the container (as long as it's also installed in it)
- Added `clean`, which stops and delete container then delete image
- `dockered` task uses `execute` shortcut
