### PR TITLE
Rename kano_source_directory environment variable

### DIFF
--- a/.kano/environment
+++ b/.kano/environment
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+export KANO_ROOT_DIRECTORY="$PWD/sources"
 export BUILD_DIRECTORY="$PWD/build"
 export RELEASE_DIRECTORY="$PWD/release"
 export SOURCE_DIRECTORY="$PWD/sources"

--- a/.kano/tasks/dev
+++ b/.kano/tasks/dev
@@ -42,5 +42,4 @@ dev() {
 
 _is_kano_dev_version() {
   [ "$(readlink "$EXECUTABLE_DIRECTORY/kano")" = "$SOURCE_DIRECTORY/kano" ]
-  return $?
 }

--- a/.kano/tasks/test
+++ b/.kano/tasks/test
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . "$KANO_HELPERS/does_directory_exist"
-. "$KANO_HELPERS/does_symbol_exist"
 . "$KANO_HELPERS/fail"
 . "$KANO_HELPERS/report"
 
@@ -14,22 +13,16 @@ test_help() {
 test() {
   SUITE_NAME="$1"
 
-  if [ -n "$SUITE_NAME" ]; then
-    SUITE_PATH="$TEST_SUITE_DIRECTORY/$SUITE_NAME"
-    if does_directory_exist "$SUITE_PATH"; then
-      _info "Running $SUITE_NAME tests"
-      _test "$SUITE_PATH"
-      return $?
+  if [ -z "$SUITE_NAME" ]; then
+    _info "Running all tests"
+    _test "$TEST_SUITE_DIRECTORY"
 
-    else
-      fail "[test] No test suite named '$SUITE_NAME'"
-    fi
+  elif does_directory_exist "$TEST_SUITE_DIRECTORY/$SUITE_NAME"; then
+    _info "Running $SUITE_NAME tests"
+    _test "$TEST_SUITE_DIRECTORY/$SUITE_NAME"
 
   else
-    SUITE_PATH="$TEST_SUITE_DIRECTORY"
-    _info "Running all tests"
-    _test "$SUITE_PATH"
-    return $?
+    fail "[test] No test suite named '$SUITE_NAME'"
   fi
 }
 
@@ -37,8 +30,6 @@ _test() {
   SUITE_PATH="$1"
 
   # Ensure that the kano code under test is the one in the source directory
-  INITIAL_KANO_SOURCE_DIRECTORY="$KANO_SOURCE_DIRECTORY"
-  INITIAL_KANO_BUILTIN_DIRECTORY="$KANO_BUILTIN_DIRECTORY"
   INITIAL_KANO_SYSTEM_DIRECTORY="$KANO_SYSTEM_DIRECTORY"
   INITIAL_KANO_TEAMS_DIRECTORY="$KANO_TEAMS_DIRECTORY"
   INITIAL_KANO_USER_DIRECTORY="$KANO_USER_DIRECTORY"
@@ -46,8 +37,6 @@ _test() {
   INITIAL_KANO_PROJECT_NAME="$KANO_PROJECT_NAME"
   INITIAL_KANO_TEAM="$KANO_TEAM"
 
-  export KANO_SOURCE_DIRECTORY="$SOURCE_DIRECTORY"
-  export KANO_BUILTIN_DIRECTORY="$SOURCE_DIRECTORY/builtin"
   export KANO_SYSTEM_DIRECTORY="$TEST_DIRECTORY/data/some_system/kano"
   export KANO_TEAMS_DIRECTORY="$TEST_DIRECTORY/data/some_home/.kano_teams"
   export KANO_USER_DIRECTORY="$TEST_DIRECTORY/data/some_home/.kano_user"
@@ -69,8 +58,6 @@ _test() {
   RESULT=$?
 
   # Reset environment
-  export KANO_SOURCE_DIRECTORY="$INITIAL_KANO_SOURCE_DIRECTORY"
-  export KANO_BUILTIN_DIRECTORY="$INITIAL_KANO_BUILTIN_DIRECTORY"
   export KANO_SYSTEM_DIRECTORY="$INITIAL_KANO_SYSTEM_DIRECTORY"
   export KANO_TEAMS_DIRECTORY="$INITIAL_KANO_TEAMS_DIRECTORY"
   export KANO_USER_DIRECTORY="$INITIAL_KANO_USER_DIRECTORY"

--- a/sources/builtin/helpers/confirm
+++ b/sources/builtin/helpers/confirm
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/colorize"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/colorize"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
 
 confirm() {
   while [ "$#" -gt 0 ]; do

--- a/sources/builtin/helpers/fail
+++ b/sources/builtin/helpers/fail
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
 
 fail() {
   MESSAGE="$1"

--- a/sources/builtin/helpers/find_this_directory
+++ b/sources/builtin/helpers/find_this_directory
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_file_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/get_absolute_directory_path"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/is_symbolic_link"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_file_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/get_absolute_directory_path"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/is_symbolic_link"
 
 find_this_directory() {
   EXECUTABLE_FILE_PATH="$(_get_initial_executable_file_path)"

--- a/sources/builtin/helpers/press_enter_to_continue
+++ b/sources/builtin/helpers/press_enter_to_continue
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/colorize"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/colorize"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
 
 press_enter_to_continue() {
   MESSAGE="${1-"Press ENTER to continue"}"

--- a/sources/builtin/helpers/report
+++ b/sources/builtin/helpers/report
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/colorize"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/colorize"
 
 report() {
   message() {

--- a/sources/builtin/helpers/succeed
+++ b/sources/builtin/helpers/succeed
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
 
 succeed() {
   MESSAGE="$1"

--- a/sources/builtin/tasks/docker
+++ b/sources/builtin/tasks/docker
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_file_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_file_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/fail"
 
 docker_help() {
   echo "Develop in a docker container"
@@ -163,7 +163,7 @@ docker() {
         --log-driver none \
         --name "$KANO_DOCKER_CONTAINER" \
         --rm \
-        --volume "$KANO_SOURCE_DIRECTORY:/opt/kano/lib" \
+        --volume "$KANO_ROOT_DIRECTORY:/opt/kano/lib" \
         --volume "$PWD:$PWD" \
         --workdir "$PWD" \
         "$@" \

--- a/sources/builtin/tasks/help
+++ b/sources/builtin/tasks/help
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/colorize"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_symbol_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/list_files_in_directory"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
-. "$KANO_SOURCE_DIRECTORY/scopes"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/colorize"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_symbol_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/list_files_in_directory"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
+. "$KANO_ROOT_DIRECTORY/scopes"
 
 help_help() {
   echo "Show this help message"

--- a/sources/builtin/tasks/init
+++ b/sources/builtin/tasks/init
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/am_i_root"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_directory_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/am_i_root"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_directory_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/fail"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
 
 init_help() {
   echo "Initialize tasks and/or kano directories"

--- a/sources/kano
+++ b/sources/kano
@@ -1,30 +1,32 @@
 #!/bin/sh -e
 
 kano() {
-  KANO_SOURCE_DIRECTORY="$(_find_kano_installation_directory)"
-  export KANO_SOURCE_DIRECTORY
-  export KANO_BUILTIN_DIRECTORY="$KANO_SOURCE_DIRECTORY/builtin"
+  if [ -h "$0" ]; then
+    KANO_EXECUTABLE="$(readlink "$0")"
+
+  else
+    KANO_EXECUTABLE="$0"
+  fi
+
+  KANO_ROOT_DIRECTORY="$(dirname "$KANO_EXECUTABLE")"
+  export KANO_ROOT_DIRECTORY
+
+  # Deprecated, use $KANO_ROOT_DIRECTORY
+  export KANO_SOURCE_DIRECTORY="$KANO_ROOT_DIRECTORY"
+
+  # Deprecated, not intended as public variable, will be removed
+  export KANO_BUILTIN_DIRECTORY="$KANO_ROOT_DIRECTORY/builtin"
+
+  export KANO_HELPERS="$KANO_ROOT_DIRECTORY/builtin/helpers"
   export KANO_SYSTEM_DIRECTORY="/etc/kano"
   export KANO_TEAMS_DIRECTORY="$HOME/.kano_teams"
   export KANO_USER_DIRECTORY="$HOME/.kano_user"
   export KANO_PROJECT_DIRECTORY="$PWD/.kano"
-
   KANO_PROJECT_NAME="$(basename "$PWD")"
   export KANO_PROJECT_NAME
 
-  export KANO_HELPERS="$KANO_BUILTIN_DIRECTORY/helpers"
-
-  . "$KANO_SOURCE_DIRECTORY/router"
+  . "$KANO_ROOT_DIRECTORY/router"
   router route "$@"
-}
-
-_find_kano_installation_directory() {
-  KANO_EXECUTABLE="$0"
-  if [ -h "$KANO_EXECUTABLE" ]; then
-    KANO_EXECUTABLE="$(readlink "$KANO_EXECUTABLE")"
-  fi
-
-  dirname "$KANO_EXECUTABLE"
 }
 
 kano "$@"

--- a/sources/router
+++ b/sources/router
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
-. "$KANO_SOURCE_DIRECTORY/scopes"
-. "$KANO_SOURCE_DIRECTORY/tasks"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/fail"
+. "$KANO_ROOT_DIRECTORY/scopes"
+. "$KANO_ROOT_DIRECTORY/tasks"
 
 router() {
   route() {

--- a/sources/scopes
+++ b/sources/scopes
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_directory_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_directory_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/fail"
 
 scopes() {
   PROJECT_SCOPE="project"
@@ -91,7 +91,7 @@ scopes() {
         ;;
 
       "$BUILTIN_SCOPE")
-        echo "$KANO_BUILTIN_DIRECTORY"
+        echo "$KANO_ROOT_DIRECTORY/builtin"
         ;;
 
       *)

--- a/sources/tasks
+++ b/sources/tasks
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_file_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_symbol_exist"
-. "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
-. "$KANO_SOURCE_DIRECTORY/scopes"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_file_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/does_symbol_exist"
+. "$KANO_ROOT_DIRECTORY/builtin/helpers/fail"
+. "$KANO_ROOT_DIRECTORY/scopes"
 
 tasks() {
   find_scope() {

--- a/tests/suites/integration/builtin/helpers/does_directory_exist.test
+++ b/tests/suites/integration/builtin/helpers/does_directory_exist.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_directory_exist"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/does_directory_exist"
 
 TEST_DATA_DIRECTORY="$TEST_DIRECTORY/data/does_directory_exist_test"
 

--- a/tests/suites/integration/builtin/helpers/does_file_exist.test
+++ b/tests/suites/integration/builtin/helpers/does_file_exist.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_file_exist"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/does_file_exist"
 
 TEST_DATA_DIRECTORY="$TEST_DIRECTORY/data/does_file_exist_test"
 

--- a/tests/suites/integration/builtin/helpers/find_and_replace_in_directory.test
+++ b/tests/suites/integration/builtin/helpers/find_and_replace_in_directory.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/find_and_replace_in_directory"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/find_and_replace_in_directory"
 
 TEST_DATA_DIRECTORY="$TEST_DIRECTORY/data/find_and_replace_in_directory_test"
 

--- a/tests/suites/integration/builtin/helpers/get_absolute_directory_path.test
+++ b/tests/suites/integration/builtin/helpers/get_absolute_directory_path.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/get_absolute_directory_path"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/get_absolute_directory_path"
 
 TEST_DATA_DIRECTORY="$TEST_DIRECTORY/data/get_absolute_directory_path_test"
 

--- a/tests/suites/integration/builtin/helpers/is_symbolic_link.test
+++ b/tests/suites/integration/builtin/helpers/is_symbolic_link.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/is_symbolic_link"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/is_symbolic_link"
 
 TEST_DATA_DIRECTORY="$TEST_DIRECTORY/data/is_symbolic_link_test"
 

--- a/tests/suites/integration/builtin/helpers/list_files_in_directory.test
+++ b/tests/suites/integration/builtin/helpers/list_files_in_directory.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/list_files_in_directory"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/list_files_in_directory"
 
 TEST_DATA_DIRECTORY="$TEST_DIRECTORY/data/list_files_in_directory_test"
 

--- a/tests/suites/integration/builtin/tasks/init.test
+++ b/tests/suites/integration/builtin/tasks/init.test
@@ -2,7 +2,7 @@
 
 . "$KANO_HELPERS/does_symbol_exist"
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/init"
+Include "$KANO_ROOT_DIRECTORY/builtin/tasks/init"
 
 SOME_TASK="some_task"
 

--- a/tests/suites/integration/router.test
+++ b/tests/suites/integration/router.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/router"
+Include "$KANO_ROOT_DIRECTORY/router"
 
 SOME_TASK="some_task"
 SOME_PARAMETER="some_parameter"

--- a/tests/suites/unit/builtin/helpers/am_i_root.test
+++ b/tests/suites/unit/builtin/helpers/am_i_root.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/am_i_root"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/am_i_root"
 
 ROOT_USER_ID="0"
 SOME_NON_ROOT_USER_ID="300"

--- a/tests/suites/unit/builtin/helpers/colorize.test
+++ b/tests/suites/unit/builtin/helpers/colorize.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/colorize"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/colorize"
 
 SOME_TEXT="some text"
 

--- a/tests/suites/unit/builtin/helpers/confirm.test
+++ b/tests/suites/unit/builtin/helpers/confirm.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/confirm"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/confirm"
 
 SOME_QUESTION="Some question?"
 

--- a/tests/suites/unit/builtin/helpers/does_symbol_exist.test
+++ b/tests/suites/unit/builtin/helpers/does_symbol_exist.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/does_symbol_exist"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/does_symbol_exist"
 
 SOME_SYMBOL="some_symbol"
 

--- a/tests/suites/unit/builtin/helpers/fail.test
+++ b/tests/suites/unit/builtin/helpers/fail.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/fail"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/fail"
 
 SOME_ERROR_MESSAGE="Some error message"
 

--- a/tests/suites/unit/builtin/helpers/find_this_directory.test
+++ b/tests/suites/unit/builtin/helpers/find_this_directory.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/find_this_directory"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/find_this_directory"
 
 Describe "find_this_directory"
   is_symbolic_link() {

--- a/tests/suites/unit/builtin/helpers/press_enter_to_continue.test
+++ b/tests/suites/unit/builtin/helpers/press_enter_to_continue.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/press_enter_to_continue"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/press_enter_to_continue"
 
 SOME_MESSAGE="Some message"
 

--- a/tests/suites/unit/builtin/helpers/report.test
+++ b/tests/suites/unit/builtin/helpers/report.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/report"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/report"
 
 SOME_MESSAGE="some message"
 SOME_COLOR="purple"

--- a/tests/suites/unit/builtin/helpers/succeed.test
+++ b/tests/suites/unit/builtin/helpers/succeed.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/helpers/succeed"
+Include "$KANO_ROOT_DIRECTORY/builtin/helpers/succeed"
 
 SOME_SUCCESS_MESSAGE="Some success message"
 

--- a/tests/suites/unit/builtin/tasks/docker.test
+++ b/tests/suites/unit/builtin/tasks/docker.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/docker"
+Include "$KANO_ROOT_DIRECTORY/builtin/tasks/docker"
 
 Describe "docker"
   DEFAULT_FILE="$KANO_PROJECT_DIRECTORY/Dockerfile"
@@ -786,7 +786,7 @@ Describe "docker"
             The variable docker_called_with should include "--name $DEFAULT_CONTAINER"
             The variable docker_called_with should include "--rm"
             The variable docker_called_with should include \
-              "--volume $KANO_SOURCE_DIRECTORY:/opt/kano/lib"
+              "--volume $KANO_ROOT_DIRECTORY:/opt/kano/lib"
             The variable docker_called_with should include "--volume $PWD:$PWD"
             The variable docker_called_with should include "--workdir $PWD"
             The variable docker_called_with should end_with \

--- a/tests/suites/unit/builtin/tasks/dockered.test
+++ b/tests/suites/unit/builtin/tasks/dockered.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/dockered"
+Include "$KANO_ROOT_DIRECTORY/builtin/tasks/dockered"
 
 Describe "dockered"
   _kano() {

--- a/tests/suites/unit/builtin/tasks/help.test
+++ b/tests/suites/unit/builtin/tasks/help.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/help"
+Include "$KANO_ROOT_DIRECTORY/builtin/tasks/help"
 
 SOME_SCOPE_1="some_scope_1"
 SOME_SCOPE_2="some_scope_2"

--- a/tests/suites/unit/builtin/tasks/init.test
+++ b/tests/suites/unit/builtin/tasks/init.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/builtin/tasks/init"
+Include "$KANO_ROOT_DIRECTORY/builtin/tasks/init"
 
 SOME_TEAM="some_team"
 

--- a/tests/suites/unit/router.test
+++ b/tests/suites/unit/router.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/router"
+Include "$KANO_ROOT_DIRECTORY/router"
 
 SOME_FLAG="-u"
 SOME_SCOPE="some_scope"

--- a/tests/suites/unit/scopes.test
+++ b/tests/suites/unit/scopes.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/scopes"
+Include "$KANO_ROOT_DIRECTORY/scopes"
 
 SOME_TEAM="some_team"
 
@@ -193,7 +193,7 @@ project"
       It "should return builtin directory"
         When run scopes to_directory "builtin"
         The status should be success
-        The output should equal "$KANO_BUILTIN_DIRECTORY"
+        The output should equal "$KANO_ROOT_DIRECTORY/builtin"
       End
     End
   End

--- a/tests/suites/unit/tasks.test
+++ b/tests/suites/unit/tasks.test
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-Include "$KANO_SOURCE_DIRECTORY/tasks"
+Include "$KANO_ROOT_DIRECTORY/tasks"
 
 SOME_SCOPE_1="some_scope_1"
 SOME_SCOPE_2="some_scope_2"


### PR DESCRIPTION
rename to kano_root_directory
set to local source directory in .kano/environment for local tasks
deprecate kano_source_directory
deprecate kano_builtin_directory, not meant as public